### PR TITLE
Try the new Tizen scripts

### DIFF
--- a/.github/workflows/setup-tools/action.yml
+++ b/.github/workflows/setup-tools/action.yml
@@ -13,10 +13,7 @@ runs:
   - name: Setup .NET
     uses: actions/setup-dotnet@v4
     with:
-      dotnet-version: 8.0.304
-  - name: Show .NET Info
-    shell: pwsh
-    run: dotnet new globaljson --sdk-version 8.0.304
+      dotnet-version: 8.0.x
   - name: Show .NET Info
     shell: pwsh
     run: dotnet --info

--- a/.github/workflows/setup-tools/action.yml
+++ b/.github/workflows/setup-tools/action.yml
@@ -22,14 +22,18 @@ runs:
       dotnet-version: 8.0.304
   - name: Force .NET version
     if: runner.os != 'Windows'
+    shell: pwsh
     run: dotnet new globaljson --sdk-version 8.0.304
   - name: Show .NET Info
+    shell: pwsh
     run: dotnet --info
   - name: Setup .NET MAUI
     if: runner.os == 'Linux'
+    shell: pwsh
     run: dotnet workload install maui-android --source https://api.nuget.org/v3/index.json
   - name: Setup .NET MAUI
     if: runner.os == 'macOS'
+    shell: pwsh
     run: dotnet workload install maui --source https://api.nuget.org/v3/index.json
   - name: Setup Tizen.NET
     if: runner.os != 'Windows'

--- a/.github/workflows/setup-tools/action.yml
+++ b/.github/workflows/setup-tools/action.yml
@@ -12,7 +12,6 @@ runs:
       xcode-version: latest-stable
   - name: Setup .NET
     uses: actions/setup-dotnet@v4
-    if: runner.os == 'Windows'
     with:
       dotnet-version: 8.0.x
   - name: Show .NET Info

--- a/.github/workflows/setup-tools/action.yml
+++ b/.github/workflows/setup-tools/action.yml
@@ -15,15 +15,6 @@ runs:
     if: runner.os == 'Windows'
     with:
       dotnet-version: 8.0.x
-  - name: Setup .NET
-    uses: actions/setup-dotnet@v4
-    if: runner.os != 'Windows'
-    with:
-      dotnet-version: 8.0.304
-  - name: Force .NET version
-    if: runner.os != 'Windows'
-    shell: pwsh
-    run: dotnet new globaljson --sdk-version 8.0.304
   - name: Show .NET Info
     shell: pwsh
     run: dotnet --info

--- a/.github/workflows/setup-tools/action.yml
+++ b/.github/workflows/setup-tools/action.yml
@@ -12,18 +12,24 @@ runs:
       xcode-version: latest-stable
   - name: Setup .NET
     uses: actions/setup-dotnet@v4
+    if: runner.os == 'Windows'
     with:
       dotnet-version: 8.0.x
+  - name: Setup .NET
+    uses: actions/setup-dotnet@v4
+    if: runner.os != 'Windows'
+    with:
+      dotnet-version: 8.0.304
+  - name: Force .NET version
+    if: runner.os != 'Windows'
+    run: dotnet new globaljson --sdk-version 8.0.304
   - name: Show .NET Info
-    shell: pwsh
     run: dotnet --info
   - name: Setup .NET MAUI
     if: runner.os == 'Linux'
-    shell: pwsh
     run: dotnet workload install maui-android --source https://api.nuget.org/v3/index.json
   - name: Setup .NET MAUI
     if: runner.os == 'macOS'
-    shell: pwsh
     run: dotnet workload install maui --source https://api.nuget.org/v3/index.json
   - name: Setup Tizen.NET
     if: runner.os != 'Windows'


### PR DESCRIPTION
The new Tizen scripts have a fallback to install the older workloads on the new SDKs.