### PR TITLE
Add loose-file MSIX registration to CLI for Windows packaged app testing

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -111,6 +111,7 @@ stages:
       - template: templates/test-tcp-ios.yml
       - template: templates/test-tcp-macos.yml
       - template: templates/test-tcp-windows.yml
+      - template: templates/test-tcp-windows-loose.yml
       - template: templates/test-tcp-windows-unpackaged.yml
 
   - stage: XHarness_Device_Tests

--- a/.azure/templates/test-tcp-windows-loose.yml
+++ b/.azure/templates/test-tcp-windows-loose.yml
@@ -40,9 +40,6 @@ jobs:
             /bl:./artifacts/logs/msbuild-build-loose.binlog
         displayName: 'Build App (loose layout)'
       - pwsh: |
-          Get-AppxPackage -Name "com.companyname.devicetestingkitapp.devicetests" -ErrorAction SilentlyContinue | Remove-AppxPackage -ErrorAction SilentlyContinue
-        displayName: 'Remove any conflicting package registration'
-      - pwsh: |
           $buildOutput = "artifacts/bin/DeviceTestingKitApp.DeviceTests"
           $manifest = Get-ChildItem -Path $buildOutput -Filter "AppxManifest.xml" -Recurse | Select-Object -First 1
           if (-not $manifest) { Write-Error "No AppxManifest.xml found in $buildOutput"; exit 1 }

--- a/.azure/templates/test-tcp-windows-loose.yml
+++ b/.azure/templates/test-tcp-windows-loose.yml
@@ -1,0 +1,52 @@
+parameters:
+  - name: poolImage
+    type: string
+    default: 'windows-2025'
+  - name: targetFramework
+    type: string
+    default: 'net10.0-windows10.0.19041.0'
+  - name: runtimeIdentifier
+    type: string
+    default: 'win10-x64'
+  - name: configuration
+    type: string
+    default: 'release'
+
+jobs:
+  - job: TCP_Windows_Loose
+    displayName: 'TCP Windows (Loose MSIX)'
+    pool:
+      vmImage: ${{ parameters.poolImage }}
+    variables:
+      TEST_TARGET_FRAMEWORK: ${{ parameters.targetFramework }}
+      TEST_RUNTIME_IDENTIFIER: ${{ parameters.runtimeIdentifier }}
+      TEST_CONFIGURATION: ${{ parameters.configuration }}
+    steps:
+      - checkout: self
+      - template: setup-tools.yml
+      - pwsh: |
+          dotnet pack src/DeviceRunners.Cli/DeviceRunners.Cli.csproj -c release
+          dotnet tool install --global DeviceRunners.Cli
+        displayName: 'Build and Install CLI Tool'
+      - pwsh: |
+          dotnet build sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj `
+            -f $(TEST_TARGET_FRAMEWORK) `
+            -c $(TEST_CONFIGURATION) `
+            -p:TestingMode=NonInteractiveVisual `
+            /bl:./artifacts/logs/msbuild-build-loose.binlog
+        displayName: 'Build App (loose layout)'
+      - pwsh: |
+          $buildOutput = "artifacts/bin/DeviceTestingKitApp.DeviceTests/$(TEST_CONFIGURATION)_$(TEST_TARGET_FRAMEWORK)"
+          $manifest = Get-ChildItem -Path $buildOutput -Filter "AppxManifest.xml" -Recurse | Select-Object -First 1
+          if (-not $manifest) { Write-Error "No AppxManifest.xml found in $buildOutput"; exit 1 }
+          device-runners windows test --app $manifest.DirectoryName --results-directory artifacts/test-results
+        displayName: 'Run Tests with Loose MSIX Layout'
+      - pwsh: |
+          Remove-Item -Recurse -Force ./artifacts/bin -ErrorAction SilentlyContinue
+          Remove-Item -Recurse -Force ./artifacts/obj -ErrorAction SilentlyContinue
+        displayName: 'Clean up build artifacts before upload'
+        condition: always()
+      - publish: ./artifacts
+        artifact: 'Test Results (TCP) - Windows Loose MSIX'
+        displayName: 'Upload Artifacts'
+        condition: always()

--- a/.azure/templates/test-tcp-windows-loose.yml
+++ b/.azure/templates/test-tcp-windows-loose.yml
@@ -37,6 +37,7 @@ jobs:
             -f $(TEST_TARGET_FRAMEWORK) `
             -c $(TEST_CONFIGURATION) `
             -p:TestingMode=NonInteractiveVisual `
+            -p:WindowsAppSDKSelfContained=true `
             /bl:./artifacts/logs/msbuild-build-loose.binlog
         displayName: 'Build App (loose layout)'
       - pwsh: |

--- a/.azure/templates/test-tcp-windows-loose.yml
+++ b/.azure/templates/test-tcp-windows-loose.yml
@@ -40,6 +40,18 @@ jobs:
             /bl:./artifacts/logs/msbuild-build-loose.binlog
         displayName: 'Build App (loose layout)'
       - pwsh: |
+          $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'win10-arm64' } else { 'win10-x64' }
+          $wasdkDir = Get-ChildItem "$env:USERPROFILE/.nuget/packages/microsoft.windowsappsdk" -Directory |
+            Sort-Object Name -Descending | Select-Object -First 1
+          if (-not $wasdkDir) { Write-Error "WindowsAppSDK NuGet package not found"; exit 1 }
+          $msixDir = Join-Path $wasdkDir.FullName "tools/MSIX/$arch"
+          Write-Host "Installing WinAppSDK runtime from: $msixDir"
+          Get-ChildItem "$msixDir/*.msix" | ForEach-Object {
+            Write-Host "  Installing: $($_.Name)"
+            Add-AppxPackage -Path $_.FullName -ErrorAction SilentlyContinue
+          }
+        displayName: 'Install Windows App Runtime framework'
+      - pwsh: |
           $buildOutput = "artifacts/bin/DeviceTestingKitApp.DeviceTests"
           $manifest = Get-ChildItem -Path $buildOutput -Filter "AppxManifest.xml" -Recurse | Select-Object -First 1
           if (-not $manifest) { Write-Error "No AppxManifest.xml found in $buildOutput"; exit 1 }

--- a/.azure/templates/test-tcp-windows-loose.yml
+++ b/.azure/templates/test-tcp-windows-loose.yml
@@ -37,8 +37,6 @@ jobs:
             -f $(TEST_TARGET_FRAMEWORK) `
             -c $(TEST_CONFIGURATION) `
             -p:TestingMode=NonInteractiveVisual `
-            -p:WindowsAppSDKSelfContained=true `
-            -p:RuntimeIdentifier=win-x64 `
             /bl:./artifacts/logs/msbuild-build-loose.binlog
         displayName: 'Build App (loose layout)'
       - pwsh: |

--- a/.azure/templates/test-tcp-windows-loose.yml
+++ b/.azure/templates/test-tcp-windows-loose.yml
@@ -38,13 +38,15 @@ jobs:
             -c $(TEST_CONFIGURATION) `
             -p:TestingMode=NonInteractiveVisual `
             -p:WindowsAppSDKSelfContained=true `
+            -p:SelfContained=true `
+            -r win-x64 `
             /bl:./artifacts/logs/msbuild-build-loose.binlog
         displayName: 'Build App (loose layout)'
       - pwsh: |
           Get-AppxPackage -Name "com.companyname.devicetestingkitapp.devicetests" -ErrorAction SilentlyContinue | Remove-AppxPackage -ErrorAction SilentlyContinue
         displayName: 'Remove any conflicting package registration'
       - pwsh: |
-          $buildOutput = "artifacts/bin/DeviceTestingKitApp.DeviceTests/$(TEST_CONFIGURATION)_$(TEST_TARGET_FRAMEWORK)"
+          $buildOutput = "artifacts/bin/DeviceTestingKitApp.DeviceTests"
           $manifest = Get-ChildItem -Path $buildOutput -Filter "AppxManifest.xml" -Recurse | Select-Object -First 1
           if (-not $manifest) { Write-Error "No AppxManifest.xml found in $buildOutput"; exit 1 }
           device-runners windows test --app $manifest.DirectoryName --results-directory artifacts/test-results

--- a/.azure/templates/test-tcp-windows-loose.yml
+++ b/.azure/templates/test-tcp-windows-loose.yml
@@ -40,6 +40,9 @@ jobs:
             /bl:./artifacts/logs/msbuild-build-loose.binlog
         displayName: 'Build App (loose layout)'
       - pwsh: |
+          Get-AppxPackage -Name "com.companyname.devicetestingkitapp.devicetests" -ErrorAction SilentlyContinue | Remove-AppxPackage -ErrorAction SilentlyContinue
+        displayName: 'Remove any conflicting package registration'
+      - pwsh: |
           $buildOutput = "artifacts/bin/DeviceTestingKitApp.DeviceTests/$(TEST_CONFIGURATION)_$(TEST_TARGET_FRAMEWORK)"
           $manifest = Get-ChildItem -Path $buildOutput -Filter "AppxManifest.xml" -Recurse | Select-Object -First 1
           if (-not $manifest) { Write-Error "No AppxManifest.xml found in $buildOutput"; exit 1 }

--- a/.azure/templates/test-tcp-windows-loose.yml
+++ b/.azure/templates/test-tcp-windows-loose.yml
@@ -38,8 +38,7 @@ jobs:
             -c $(TEST_CONFIGURATION) `
             -p:TestingMode=NonInteractiveVisual `
             -p:WindowsAppSDKSelfContained=true `
-            -p:SelfContained=true `
-            -r win-x64 `
+            -p:RuntimeIdentifier=win-x64 `
             /bl:./artifacts/logs/msbuild-build-loose.binlog
         displayName: 'Build App (loose layout)'
       - pwsh: |

--- a/.azure/templates/test-tcp-windows-loose.yml
+++ b/.azure/templates/test-tcp-windows-loose.yml
@@ -25,6 +25,10 @@ jobs:
       - checkout: self
       - template: setup-tools.yml
       - pwsh: |
+          reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /v AllowDevelopmentWithoutDevLicense /t REG_DWORD /d 1 /f
+          reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /v AllowAllTrustedApps /t REG_DWORD /d 1 /f
+        displayName: 'Enable Windows Developer Mode'
+      - pwsh: |
           dotnet pack src/DeviceRunners.Cli/DeviceRunners.Cli.csproj -c release
           dotnet tool install --global DeviceRunners.Cli
         displayName: 'Build and Install CLI Tool'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,21 @@ jobs:
         reporter: dotnet-trx
         fail-on-empty: 'false'
 
+  tcp-windows-loose:
+    name: TCP Windows (Loose MSIX)
+    runs-on: windows-2025
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/workflows/test-tcp-windows-loose
+    - name: Test Report
+      uses: dorny/test-reporter@v2
+      if: (always() && !cancelled())
+      with:
+        name: Test Results (TCP Windows Loose MSIX)
+        path: ./artifacts/test-results/*.trx
+        reporter: dotnet-trx
+        fail-on-empty: 'false'
+
   tcp-windows-unpackaged:
     name: TCP Windows (EXE)
     runs-on: windows-2025

--- a/.github/workflows/test-tcp-windows-loose/action.yml
+++ b/.github/workflows/test-tcp-windows-loose/action.yml
@@ -38,6 +38,10 @@ runs:
           -c ${{ inputs.configuration }} `
           -p:TestingMode=NonInteractiveVisual `
           /bl:./artifacts/logs/msbuild-build-loose.binlog
+    - name: Remove any conflicting package registration
+      shell: pwsh
+      run: |
+        Get-AppxPackage -Name "com.companyname.devicetestingkitapp.devicetests" -ErrorAction SilentlyContinue | Remove-AppxPackage -ErrorAction SilentlyContinue
     - name: Run Tests with Loose MSIX Layout
       shell: pwsh
       run: |

--- a/.github/workflows/test-tcp-windows-loose/action.yml
+++ b/.github/workflows/test-tcp-windows-loose/action.yml
@@ -37,6 +37,7 @@ runs:
           -f ${{ inputs.target-framework }} `
           -c ${{ inputs.configuration }} `
           -p:TestingMode=NonInteractiveVisual `
+          -p:WindowsAppSDKSelfContained=true `
           /bl:./artifacts/logs/msbuild-build-loose.binlog
     - name: Remove any conflicting package registration
       shell: pwsh

--- a/.github/workflows/test-tcp-windows-loose/action.yml
+++ b/.github/workflows/test-tcp-windows-loose/action.yml
@@ -37,8 +37,6 @@ runs:
           -f ${{ inputs.target-framework }} `
           -c ${{ inputs.configuration }} `
           -p:TestingMode=NonInteractiveVisual `
-          -p:WindowsAppSDKSelfContained=true `
-          -p:RuntimeIdentifier=win-x64 `
           /bl:./artifacts/logs/msbuild-build-loose.binlog
     - name: Remove any conflicting package registration
       shell: pwsh

--- a/.github/workflows/test-tcp-windows-loose/action.yml
+++ b/.github/workflows/test-tcp-windows-loose/action.yml
@@ -38,6 +38,19 @@ runs:
           -c ${{ inputs.configuration }} `
           -p:TestingMode=NonInteractiveVisual `
           /bl:./artifacts/logs/msbuild-build-loose.binlog
+    - name: Install Windows App Runtime framework
+      shell: pwsh
+      run: |
+        $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'win10-arm64' } else { 'win10-x64' }
+        $wasdkDir = Get-ChildItem "$env:USERPROFILE/.nuget/packages/microsoft.windowsappsdk" -Directory |
+          Sort-Object Name -Descending | Select-Object -First 1
+        if (-not $wasdkDir) { Write-Error "WindowsAppSDK NuGet package not found"; exit 1 }
+        $msixDir = Join-Path $wasdkDir.FullName "tools/MSIX/$arch"
+        Write-Host "Installing WinAppSDK runtime from: $msixDir"
+        Get-ChildItem "$msixDir/*.msix" | ForEach-Object {
+          Write-Host "  Installing: $($_.Name)"
+          Add-AppxPackage -Path $_.FullName -ErrorAction SilentlyContinue
+        }
     - name: Run Tests with Loose MSIX Layout
       shell: pwsh
       run: |

--- a/.github/workflows/test-tcp-windows-loose/action.yml
+++ b/.github/workflows/test-tcp-windows-loose/action.yml
@@ -20,6 +20,11 @@ runs:
   steps:
     - name: Setup Required Tools
       uses: ./.github/workflows/setup-tools
+    - name: Enable Windows Developer Mode
+      shell: pwsh
+      run: |
+        reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /v AllowDevelopmentWithoutDevLicense /t REG_DWORD /d 1 /f
+        reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /v AllowAllTrustedApps /t REG_DWORD /d 1 /f
     - name: Build and Install CLI Tool
       shell: pwsh
       run: |

--- a/.github/workflows/test-tcp-windows-loose/action.yml
+++ b/.github/workflows/test-tcp-windows-loose/action.yml
@@ -38,8 +38,7 @@ runs:
           -c ${{ inputs.configuration }} `
           -p:TestingMode=NonInteractiveVisual `
           -p:WindowsAppSDKSelfContained=true `
-          -p:SelfContained=true `
-          -r win-x64 `
+          -p:RuntimeIdentifier=win-x64 `
           /bl:./artifacts/logs/msbuild-build-loose.binlog
     - name: Remove any conflicting package registration
       shell: pwsh

--- a/.github/workflows/test-tcp-windows-loose/action.yml
+++ b/.github/workflows/test-tcp-windows-loose/action.yml
@@ -38,10 +38,6 @@ runs:
           -c ${{ inputs.configuration }} `
           -p:TestingMode=NonInteractiveVisual `
           /bl:./artifacts/logs/msbuild-build-loose.binlog
-    - name: Remove any conflicting package registration
-      shell: pwsh
-      run: |
-        Get-AppxPackage -Name "com.companyname.devicetestingkitapp.devicetests" -ErrorAction SilentlyContinue | Remove-AppxPackage -ErrorAction SilentlyContinue
     - name: Run Tests with Loose MSIX Layout
       shell: pwsh
       run: |

--- a/.github/workflows/test-tcp-windows-loose/action.yml
+++ b/.github/workflows/test-tcp-windows-loose/action.yml
@@ -1,0 +1,54 @@
+name: 'TCP Windows Test (Loose MSIX)'
+description: 'Run TCP-based device tests on Windows using loose-file MSIX registration (no publish/cert needed)'
+
+inputs:
+  test-project:
+    description: 'Path to the test project'
+    default: 'sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj'
+  target-framework:
+    description: 'Target framework'
+    default: 'net10.0-windows10.0.19041.0'
+  configuration:
+    description: 'Build configuration'
+    default: 'release'
+  artifact-name:
+    description: 'Artifact name'
+    default: 'Test Results (TCP) - Windows (Loose MSIX)'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Required Tools
+      uses: ./.github/workflows/setup-tools
+    - name: Build and Install CLI Tool
+      shell: pwsh
+      run: |
+        dotnet pack src/DeviceRunners.Cli/DeviceRunners.Cli.csproj -c release
+        dotnet tool install --global DeviceRunners.Cli
+    - name: Build App (loose layout)
+      shell: pwsh
+      run: |
+        dotnet build ${{ inputs.test-project }} `
+          -f ${{ inputs.target-framework }} `
+          -c ${{ inputs.configuration }} `
+          -p:TestingMode=NonInteractiveVisual `
+          /bl:./artifacts/logs/msbuild-build-loose.binlog
+    - name: Run Tests with Loose MSIX Layout
+      shell: pwsh
+      run: |
+        $buildOutput = "artifacts/bin/DeviceTestingKitApp.DeviceTests/${{ inputs.configuration }}_${{ inputs.target-framework }}"
+        $manifest = Get-ChildItem -Path $buildOutput -Filter "AppxManifest.xml" -Recurse | Select-Object -First 1
+        if (-not $manifest) { Write-Error "No AppxManifest.xml found in $buildOutput"; exit 1 }
+        device-runners windows test --app $manifest.DirectoryName --results-directory artifacts/test-results --logger trx
+    - name: Clean up build artifacts before upload
+      if: always()
+      shell: pwsh
+      run: |
+        Remove-Item -Recurse -Force ./artifacts/bin -ErrorAction SilentlyContinue
+        Remove-Item -Recurse -Force ./artifacts/obj -ErrorAction SilentlyContinue
+    - name: Upload Artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ./artifacts

--- a/.github/workflows/test-tcp-windows-loose/action.yml
+++ b/.github/workflows/test-tcp-windows-loose/action.yml
@@ -38,6 +38,8 @@ runs:
           -c ${{ inputs.configuration }} `
           -p:TestingMode=NonInteractiveVisual `
           -p:WindowsAppSDKSelfContained=true `
+          -p:SelfContained=true `
+          -r win-x64 `
           /bl:./artifacts/logs/msbuild-build-loose.binlog
     - name: Remove any conflicting package registration
       shell: pwsh
@@ -46,7 +48,7 @@ runs:
     - name: Run Tests with Loose MSIX Layout
       shell: pwsh
       run: |
-        $buildOutput = "artifacts/bin/DeviceTestingKitApp.DeviceTests/${{ inputs.configuration }}_${{ inputs.target-framework }}"
+        $buildOutput = "artifacts/bin/DeviceTestingKitApp.DeviceTests"
         $manifest = Get-ChildItem -Path $buildOutput -Filter "AppxManifest.xml" -Recurse | Select-Object -First 1
         if (-not $manifest) { Write-Error "No AppxManifest.xml found in $buildOutput"; exit 1 }
         device-runners windows test --app $manifest.DirectoryName --results-directory artifacts/test-results --logger trx

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.3.1" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
     <PackageVersion Include="Spectre.Console.Testing" Version="0.54.0" />
     <PackageVersion Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />

--- a/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
@@ -18,6 +18,9 @@
     <!-- App Identifier -->
     <ApplicationId>com.companyname.devicetestingkitapp.devicetests</ApplicationId>
 
+    <!-- Bundle WinAppSDK runtime so loose-file MSIX registration works without framework install -->
+    <WindowsAppSDKSelfContained Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">true</WindowsAppSDKSelfContained>
+
     <!-- Versions -->
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>

--- a/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
@@ -18,9 +18,6 @@
     <!-- App Identifier -->
     <ApplicationId>com.companyname.devicetestingkitapp.devicetests</ApplicationId>
 
-    <!-- Bundle WinAppSDK runtime so loose-file MSIX registration works without framework install -->
-    <WindowsAppSDKSelfContained Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">true</WindowsAppSDKSelfContained>
-
     <!-- Versions -->
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <ApplicationVersion>1</ApplicationVersion>

--- a/scripts/Start-Tests.ps1
+++ b/scripts/Start-Tests.ps1
@@ -100,7 +100,7 @@ $arch = $env:PROCESSOR_ARCHITECTURE
 if ($arch -eq "AMD64") {
   $arch = "x64"
 }
-$deps = Get-ChildItem "$App\..\Dependencies\$arch\*.msix"
+$deps = Get-ChildItem "$App\..\Dependencies\$arch\*.msix" -ErrorAction SilentlyContinue
 foreach ($dep in $deps) {
   try {
     Write-Host "    Installing dependency: '$dep'"

--- a/src/DeviceRunners.Cli/Commands/Windows/TestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Windows/TestCommand.cs
@@ -26,10 +26,16 @@ public class WindowsTestCommand(IAnsiConsole console) : BaseTestCommand<WindowsT
 			WriteConsoleOutput($"[blue]PREPARATION[/]", settings);
 			WriteConsoleOutput($"[blue]============================================================[/]", settings);
 
-			// Check if this is an unpackaged app (.exe) or packaged app (.msix)
+			// Check if this is an unpackaged app (.exe), loose MSIX layout (folder/manifest), or packaged app (.msix)
 			if (string.IsNullOrEmpty(settings.App))
 			{
 				throw new ArgumentException("Application path is required. Use --app to specify the path to your application.");
+			}
+
+			var looseLayout = WinAppService.ResolveLooseLayout(settings.App);
+			if (looseLayout.HasValue)
+			{
+				return await ExecuteLoosePackagedApp(settings, looseLayout.Value.inputFolder, looseLayout.Value.manifestPath);
 			}
 
 			var extension = Path.GetExtension(settings.App).ToLowerInvariant();
@@ -140,6 +146,94 @@ public class WindowsTestCommand(IAnsiConsole console) : BaseTestCommand<WindowsT
 		WriteResult(result, settings);
 
 		// Exit codes: 0 = success, 1 = test failures, 2 = app crashed
+		return listener.ToExitCode();
+	}
+
+	private async Task<int> ExecuteLoosePackagedApp(Settings settings, string inputFolder, string manifestPath)
+	{
+		var winAppService = new WinAppService();
+
+		WriteConsoleOutput($"  - Loose MSIX layout detected.", settings);
+		WriteConsoleOutput($"    Input folder: '[green]{Markup.Escape(inputFolder)}[/]'", settings);
+		WriteConsoleOutput($"    Manifest:     '[green]{Markup.Escape(manifestPath)}[/]'", settings);
+
+		WriteConsoleOutput($"", settings);
+		WriteConsoleOutput($"[blue]============================================================[/]", settings);
+		WriteConsoleOutput($"[blue]EXECUTION[/]", settings);
+		WriteConsoleOutput($"[blue]============================================================[/]", settings);
+
+		// Register and launch the app via winapp.exe, returning immediately with PID
+		WriteConsoleOutput($"  - Registering and launching via winapp.exe (--detach)...", settings);
+		int pid;
+		try
+		{
+			pid = await winAppService.RunDetachedAsync(inputFolder, manifestPath, appArgs: null);
+		}
+		catch (Exception ex)
+		{
+			WriteConsoleOutput($"    [red]Failed to launch: {Markup.Escape(ex.Message)}[/]", settings);
+			throw;
+		}
+		WriteConsoleOutput($"    Application launched with PID: {pid}", settings);
+
+		// Handle TCP test results
+		var listener = await StartTestListener(settings);
+
+		WriteConsoleOutput($"", settings);
+		WriteConsoleOutput($"[blue]============================================================[/]", settings);
+		WriteConsoleOutput($"[blue]CLEANUP[/]", settings);
+		WriteConsoleOutput($"[blue]============================================================[/]", settings);
+
+		// Terminate the process if still running
+		WriteConsoleOutput($"  - Checking application process...", settings);
+		try
+		{
+			var process = Process.GetProcessById(pid);
+			if (!process.HasExited)
+			{
+				WriteConsoleOutput($"    Application is still running, terminating...", settings);
+				process.Kill(entireProcessTree: true);
+				process.WaitForExit(5000);
+				WriteConsoleOutput($"    Application terminated.", settings);
+			}
+			else
+			{
+				WriteConsoleOutput($"    Application has already exited.", settings);
+			}
+		}
+		catch (ArgumentException)
+		{
+			WriteConsoleOutput($"    Application process has already exited.", settings);
+		}
+		catch (Exception ex)
+		{
+			WriteConsoleOutput($"    [yellow]Warning: Failed to check/terminate process: {Markup.Escape(ex.Message)}[/]", settings);
+		}
+
+		// Unregister the development package
+		WriteConsoleOutput($"  - Unregistering development package...", settings);
+		try
+		{
+			await winAppService.UnregisterAsync(manifestPath);
+			WriteConsoleOutput($"    Package unregistered.", settings);
+		}
+		catch (Exception ex)
+		{
+			WriteConsoleOutput($"    [yellow]Warning: Failed to unregister: {Markup.Escape(ex.Message)}[/]", settings);
+		}
+
+		WriteConsoleOutput($"  - Cleanup complete.", settings);
+
+		var result = new TestStartResult
+		{
+			Success = listener.Success,
+			AppPath = settings.App,
+			ResultsDirectory = settings.ResultsDirectory,
+			TestFailures = listener.FailedCount,
+			TestResults = listener.ResultsFile
+		};
+		WriteResult(result, settings);
+
 		return listener.ToExitCode();
 	}
 

--- a/src/DeviceRunners.Cli/DeviceRunners.Cli.csproj
+++ b/src/DeviceRunners.Cli/DeviceRunners.Cli.csproj
@@ -22,8 +22,25 @@
     <PackageReference Include="AppleDev" />
   </ItemGroup>
 
+  <!-- Bundle winapp.exe for loose-file MSIX registration on Windows -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools.WinApp" PrivateAssets="all" GeneratePathProperty="true" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\DeviceRunners.VisualRunners.Core\DeviceRunners.VisualRunners.Core.csproj" />
+  </ItemGroup>
+
+  <!-- Copy both winapp.exe architectures into CLI output so the correct one is used at runtime -->
+  <ItemGroup>
+    <None Include="$(PkgMicrosoft_Windows_SDK_BuildTools_WinApp)\tools\win-x64\winapp.exe"
+          CopyToOutputDirectory="PreserveNewest"
+          Link="winapp\win-x64\winapp.exe"
+          Visible="false" />
+    <None Include="$(PkgMicrosoft_Windows_SDK_BuildTools_WinApp)\tools\win-arm64\winapp.exe"
+          CopyToOutputDirectory="PreserveNewest"
+          Link="winapp\win-arm64\winapp.exe"
+          Visible="false" />
   </ItemGroup>
 
 

--- a/src/DeviceRunners.Cli/Services/WinAppService.cs
+++ b/src/DeviceRunners.Cli/Services/WinAppService.cs
@@ -97,7 +97,9 @@ public class WinAppService
 		try
 		{
 			using var doc = JsonDocument.Parse(stdout);
-			if (doc.RootElement.TryGetProperty("pid", out var pidElement))
+			if (doc.RootElement.TryGetProperty("ProcessId", out var pidElement))
+				return pidElement.GetInt32();
+			if (doc.RootElement.TryGetProperty("pid", out pidElement))
 				return pidElement.GetInt32();
 		}
 		catch (JsonException)

--- a/src/DeviceRunners.Cli/Services/WinAppService.cs
+++ b/src/DeviceRunners.Cli/Services/WinAppService.cs
@@ -92,11 +92,8 @@ public class WinAppService
 
 		if (exitCode != 0)
 		{
-			var errorDetails = !string.IsNullOrWhiteSpace(stderr) ? stderr
-				: !string.IsNullOrWhiteSpace(stdout) ? stdout
-				: "(no output)";
 			throw new InvalidOperationException(
-				$"winapp run --detach failed (exit code {exitCode}):\n{errorDetails}");
+				$"winapp run --detach failed (exit code {exitCode}). stdout: {stdout} stderr: {stderr}");
 		}
 
 		try
@@ -140,10 +137,11 @@ public class WinAppService
 	public async Task UnregisterAsync(string manifestPath, CancellationToken cancellationToken = default)
 	{
 		var args = $"unregister --manifest \"{manifestPath}\"";
-		var (exitCode, _, stderr) = await RunProcessAsync(GetWinAppPath(), args, cancellationToken);
+		var (exitCode, stdout, stderr) = await RunProcessAsync(GetWinAppPath(), args, cancellationToken);
 
 		if (exitCode != 0)
-			Console.Error.WriteLine($"Warning: winapp unregister returned exit code {exitCode}: {stderr}");
+			throw new InvalidOperationException(
+				$"winapp unregister failed (exit code {exitCode}). stdout: {stdout} stderr: {stderr}");
 	}
 
 	internal static string BuildRunArgs(string inputFolder, string? manifestPath, string? appArgs)

--- a/src/DeviceRunners.Cli/Services/WinAppService.cs
+++ b/src/DeviceRunners.Cli/Services/WinAppService.cs
@@ -1,0 +1,175 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace DeviceRunners.Cli.Services;
+
+/// <summary>
+/// Wraps the bundled winapp.exe CLI for loose-file MSIX package registration,
+/// app launch, and cleanup. Used when the user passes a build output folder
+/// or AppxManifest.xml instead of a .msix file.
+/// </summary>
+public class WinAppService
+{
+	/// <summary>
+	/// Resolves the path to the bundled winapp.exe, selecting the correct
+	/// architecture (x64 or arm64) based on the current process.
+	/// </summary>
+	internal static string GetWinAppPath()
+	{
+		var arch = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture switch
+		{
+			System.Runtime.InteropServices.Architecture.Arm64 => "win-arm64",
+			_ => "win-x64",
+		};
+
+		var cliDir = AppContext.BaseDirectory;
+		var winappPath = Path.Combine(cliDir, "winapp", arch, "winapp.exe");
+
+		if (!File.Exists(winappPath))
+			throw new FileNotFoundException(
+				$"winapp.exe not found at '{winappPath}'. The Microsoft.Windows.SDK.BuildTools.WinApp package may not be installed.",
+				winappPath);
+
+		return winappPath;
+	}
+
+	/// <summary>
+	/// Resolves a user-provided --app value to an (inputFolder, manifestPath) pair.
+	/// Accepts:
+	///   - A folder containing AppxManifest.xml or Package.appxmanifest
+	///   - A direct path to a manifest file
+	/// Returns null if the path doesn't look like a loose-file layout.
+	/// </summary>
+	public static (string inputFolder, string manifestPath)? ResolveLooseLayout(string appPath)
+	{
+		if (Directory.Exists(appPath))
+		{
+			var manifest = FindManifestInFolder(appPath);
+			if (manifest is not null)
+				return (appPath, manifest);
+		}
+		else if (File.Exists(appPath))
+		{
+			var fileName = Path.GetFileName(appPath);
+			if (fileName.Equals("AppxManifest.xml", StringComparison.OrdinalIgnoreCase)
+				|| fileName.Equals("Package.appxmanifest", StringComparison.OrdinalIgnoreCase)
+				|| fileName.Equals("appxmanifest.xml", StringComparison.OrdinalIgnoreCase))
+			{
+				var folder = Path.GetDirectoryName(Path.GetFullPath(appPath))!;
+				return (folder, appPath);
+			}
+		}
+
+		return null;
+	}
+
+	static string? FindManifestInFolder(string folder)
+	{
+		string[] names = ["AppxManifest.xml", "Package.appxmanifest", "appxmanifest.xml"];
+		foreach (var name in names)
+		{
+			var path = Path.Combine(folder, name);
+			if (File.Exists(path))
+				return path;
+		}
+		return null;
+	}
+
+	/// <summary>
+	/// Register and launch the app, returning immediately with the PID.
+	/// Uses <c>winapp run --detach --json</c> to get structured output.
+	/// </summary>
+	public async Task<int> RunDetachedAsync(
+		string inputFolder,
+		string? manifestPath,
+		string? appArgs,
+		CancellationToken cancellationToken = default)
+	{
+		var args = BuildRunArgs(inputFolder, manifestPath, appArgs);
+		args += " --detach --json";
+
+		var (exitCode, stdout, stderr) = await RunProcessAsync(GetWinAppPath(), args, cancellationToken);
+
+		if (exitCode != 0)
+			throw new InvalidOperationException(
+				$"winapp run --detach failed (exit code {exitCode}):\n{stderr}");
+
+		try
+		{
+			using var doc = JsonDocument.Parse(stdout);
+			if (doc.RootElement.TryGetProperty("pid", out var pidElement))
+				return pidElement.GetInt32();
+		}
+		catch (JsonException)
+		{
+			// Fall through to error
+		}
+
+		throw new InvalidOperationException(
+			$"Failed to parse PID from winapp output:\n{stdout}");
+	}
+
+	/// <summary>
+	/// Register and launch the app, blocking until it exits. Returns the app exit code.
+	/// </summary>
+	public async Task<int> RunAsync(
+		string inputFolder,
+		string? manifestPath,
+		string? appArgs,
+		bool unregisterOnExit = false,
+		CancellationToken cancellationToken = default)
+	{
+		var args = BuildRunArgs(inputFolder, manifestPath, appArgs);
+		if (unregisterOnExit)
+			args += " --unregister-on-exit";
+
+		var (exitCode, _, _) = await RunProcessAsync(GetWinAppPath(), args, cancellationToken);
+		return exitCode;
+	}
+
+	/// <summary>
+	/// Unregister a development package registered via winapp run.
+	/// </summary>
+	public async Task UnregisterAsync(string manifestPath, CancellationToken cancellationToken = default)
+	{
+		var args = $"unregister --manifest \"{manifestPath}\"";
+		var (exitCode, _, stderr) = await RunProcessAsync(GetWinAppPath(), args, cancellationToken);
+
+		if (exitCode != 0)
+			Console.Error.WriteLine($"Warning: winapp unregister returned exit code {exitCode}: {stderr}");
+	}
+
+	internal static string BuildRunArgs(string inputFolder, string? manifestPath, string? appArgs)
+	{
+		var args = $"run \"{inputFolder}\"";
+		if (manifestPath is not null)
+			args += $" --manifest \"{manifestPath}\"";
+		if (!string.IsNullOrEmpty(appArgs))
+			args += $" --args \"{appArgs.Replace("\"", "\\\"")}\"";
+		return args;
+	}
+
+	static async Task<(int exitCode, string stdout, string stderr)> RunProcessAsync(
+		string fileName, string arguments, CancellationToken cancellationToken)
+	{
+		var psi = new ProcessStartInfo
+		{
+			FileName = fileName,
+			Arguments = arguments,
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			UseShellExecute = false,
+			CreateNoWindow = true,
+		};
+
+		using var process = Process.Start(psi)
+			?? throw new InvalidOperationException($"Failed to start: {fileName}");
+
+		var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+		var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+		await process.WaitForExitAsync(cancellationToken);
+
+		return (process.ExitCode, await stdoutTask, await stderrTask);
+	}
+}

--- a/src/DeviceRunners.Cli/Services/WinAppService.cs
+++ b/src/DeviceRunners.Cli/Services/WinAppService.cs
@@ -91,8 +91,13 @@ public class WinAppService
 		var (exitCode, stdout, stderr) = await RunProcessAsync(GetWinAppPath(), args, cancellationToken);
 
 		if (exitCode != 0)
+		{
+			var errorDetails = !string.IsNullOrWhiteSpace(stderr) ? stderr
+				: !string.IsNullOrWhiteSpace(stdout) ? stdout
+				: "(no output)";
 			throw new InvalidOperationException(
-				$"winapp run --detach failed (exit code {exitCode}):\n{stderr}");
+				$"winapp run --detach failed (exit code {exitCode}):\n{errorDetails}");
+		}
 
 		try
 		{


### PR DESCRIPTION
## Summary

Adds loose-file MSIX registration support to the CLI, enabling testing of packaged Windows apps directly from `dotnet build` output — no `dotnet publish`, no certificate signing, no `.msix` file needed.

This bundles [winapp.exe](https://www.nuget.org/packages/Microsoft.Windows.SDK.BuildTools.WinApp) (both x64 and arm64) into the CLI and shells out to it for package registration, launch, and cleanup.

## Three `windows test --app` modes

| `--app` value | Mode | Cert? | Build step |
|---|---|---|---|
| `path/to/app.msix` | Packaged MSIX (existing) | Yes | `dotnet publish` |
| `path/to/app.exe` | Unpackaged executable (existing) | No | `dotnet publish -p:WindowsPackageType=None` |
| **`path/to/build-output/`** | **Loose MSIX layout (new)** | **No** | **`dotnet build`** |
| **`path/to/AppxManifest.xml`** | **Loose MSIX layout (new)** | **No** | **`dotnet build`** |

### Loose MSIX flow

1. `winapp run <folder> --detach --json` → registers package from loose files + launches app → returns PID
2. CLI starts TCP listener, collects test events
3. Terminates process by PID when done
4. `winapp unregister` → removes dev package

### Usage

```bash
# Build only (no publish needed)
dotnet build MyTests.csproj -f net10.0-windows10.0.19041.0 -p:TestingMode=NonInteractiveVisual

# Test from build output folder
device-runners windows test --app ./artifacts/bin/MyTests/release_net10.0-windows/ --logger trx
```

## Changes

### New files
- **`src/DeviceRunners.Cli/Services/WinAppService.cs`** — wraps winapp.exe subprocess: `ResolveLooseLayout`, `RunDetachedAsync` (returns PID via `--json`), `RunAsync`, `UnregisterAsync`
- **`.github/workflows/test-tcp-windows-loose/action.yml`** — GitHub Actions CI for loose MSIX testing
- **`.azure/templates/test-tcp-windows-loose.yml`** — Azure DevOps CI for loose MSIX testing

### Modified files
- **`src/DeviceRunners.Cli/DeviceRunners.Cli.csproj`** — WinApp NuGet reference + MSBuild targets to copy both x64/arm64 winapp.exe to output
- **`src/DeviceRunners.Cli/Commands/Windows/TestCommand.cs`** — third code path: detects folder/manifest input via `WinAppService.ResolveLooseLayout`, registers+launches via winapp, collects TCP results, cleans up
- **`Directory.Packages.props`** — add `Microsoft.Windows.SDK.BuildTools.WinApp` 0.3.1
- **`scripts/Start-Tests.ps1`** — handle missing Dependencies folder gracefully (`-ErrorAction SilentlyContinue`)
- **`.github/workflows/ci.yml`** — add `tcp-windows-loose` job
- **`.azure/azure-pipelines.yml`** — add `test-tcp-windows-loose` template

## CI requirements for loose MSIX

- **Developer Mode** enabled (registry key set in workflow)
- **WinAppSDK framework** installed from NuGet cache (`Add-AppxPackage` on `microsoft.windowsappsdk/*/tools/MSIX/win10-x64/*.msix`)

## Testing

Verified locally end-to-end and in CI (GitHub Actions):
- 44 tests (xUnit + NUnit) run via loose layout
- TRX + JSONL results written
- App registered → launched → TCP events collected → terminated → unregistered

Relates to #109