### PR TITLE
Update XHarness, AppleDev, and AndroidSdk to latest versions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,21 +3,21 @@
   "isRoot": true,
   "tools": {
     "microsoft.dotnet.xharness.cli": {
-      "version": "11.0.0-prerelease.26107.1",
+      "version": "11.0.0-prerelease.26259.3",
       "commands": [
         "xharness"
       ],
       "rollForward": false
     },
     "androidsdk.tool": {
-      "version": "0.34.0",
+      "version": "0.35.1",
       "commands": [
         "android"
       ],
       "rollForward": false
     },
     "appledev.tools": {
-      "version": "0.8.7",
+      "version": "0.8.10",
       "commands": [
         "apple"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,11 +1,11 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="AndroidSdk" Version="0.34.0" />
-    <PackageVersion Include="AppleDev" Version="0.8.7" />
+    <PackageVersion Include="AndroidSdk" Version="0.35.1" />
+    <PackageVersion Include="AppleDev" Version="0.8.10" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageVersion Include="Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit" Version="11.0.0-prerelease.26107.1" />
-    <PackageVersion Include="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26107.1" />
-    <PackageVersion Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="11.0.0-prerelease.26107.1" />
+    <PackageVersion Include="Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit" Version="11.0.0-prerelease.26259.3" />
+    <PackageVersion Include="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26259.3" />
+    <PackageVersion Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="11.0.0-prerelease.26259.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />


### PR DESCRIPTION
## Problem

Azure DevOps build [#1323](https://dev.azure.com/mattleibow/33c0ec50-968b-4101-ab1f-ad260329d05d/_build/results?buildId=1323) on `main` is failing. The **XHarness iOS - x64** job times out after 60 minutes because the iOS simulator repeatedly fails to launch the test app:

- **Attempt 1**: `APP_LAUNCH_FAILURE` (exit 83) — *"Failed to launch the application"*
- **Attempt 2**: `APP_LAUNCH_TIMEOUT` (exit 90) — *"Run timed out after 600 seconds"*
- **Attempt 3**: Cancelled by the 60-minute job timeout

After each failure, the simulator reboot also fails (*"Failed to boot simulator"*), preventing recovery.

GitHub Actions CI is green — only AzDO device tests are affected.

## Changes

Update all tools and NuGet packages to their latest versions:

| Package | Before | After |
|---------|--------|-------|
| `microsoft.dotnet.xharness.cli` | `11.0.0-prerelease.26107.1` | `11.0.0-prerelease.26259.3` |
| `Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit` | `11.0.0-prerelease.26107.1` | `11.0.0-prerelease.26259.3` |
| `Microsoft.DotNet.XHarness.TestRunners.Common` | `11.0.0-prerelease.26107.1` | `11.0.0-prerelease.26259.3` |
| `Microsoft.DotNet.XHarness.TestRunners.Xunit` | `11.0.0-prerelease.26107.1` | `11.0.0-prerelease.26259.3` |
| `appledev.tools` / `AppleDev` | `0.8.7` | `0.8.10` |
| `androidsdk.tool` / `AndroidSdk` | `0.34.0` | `0.35.1` |

The XHarness update picks up ~5 months of improvements (26107 → 26259) which should include simulator stability fixes relevant to the iOS launch failures.