### PR TITLE
Document loose-file MSIX testing in Windows CLI and CI docs

### DIFF
--- a/docs/articles/ci-pipeline.md
+++ b/docs/articles/ci-pipeline.md
@@ -67,6 +67,7 @@ What it does:
 | `test-tcp-ios/action.yml` | Composite action | TCP iOS simulator tests |
 | `test-tcp-macos/action.yml` | Composite action | TCP Mac Catalyst tests |
 | `test-tcp-windows/action.yml` | Composite action | TCP Windows (MSIX packaged) tests |
+| `test-tcp-windows-loose/action.yml` | Composite action | TCP Windows (loose-file MSIX) tests |
 | `test-tcp-windows-unpackaged/action.yml` | Composite action | TCP Windows (unpackaged EXE) tests |
 | `test-xharness-android-linux/action.yml` | Composite action | XHarness Android tests on Linux |
 | `test-xharness-ios/action.yml` | Composite action | XHarness iOS simulator tests |
@@ -84,6 +85,7 @@ What it does:
 | `templates/test-tcp-ios.yml` | Job template | TCP iOS simulator tests |
 | `templates/test-tcp-macos.yml` | Job template | TCP Mac Catalyst tests |
 | `templates/test-tcp-windows.yml` | Job template | TCP Windows (MSIX packaged) tests |
+| `templates/test-tcp-windows-loose.yml` | Job template | TCP Windows (loose-file MSIX) tests |
 | `templates/test-tcp-windows-unpackaged.yml` | Job template | TCP Windows (unpackaged EXE) tests |
 | `templates/test-xharness-android.yml` | Job template | XHarness Android tests (Linux) |
 | `templates/test-xharness-ios.yml` | Job template | XHarness iOS simulator tests |
@@ -116,6 +118,7 @@ What it does:
 | Packaging | RID | Runner (GH) | Pool (Azure) | TCP | XHarness | Status |
 |---|---|---|---|---|---|---|
 | MSIX (packaged) | win10-x64 | windows-2025 | windows-2025 | ✅ | ✅ | **Stable** |
+| Loose MSIX (folder) | win10-x64 | windows-2025 | windows-2025 | ✅ | N/A | **Stable** — requires Developer Mode |
 | EXE (unpackaged) | win10-x64 | windows-2025 | windows-2025 | ✅ | N/A | **Stable** — TCP only |
 
 ## Device Management Patterns

--- a/docs/articles/cli-device-runner-for-windows-using-devicerunners-cli.md
+++ b/docs/articles/cli-device-runner-for-windows-using-devicerunners-cli.md
@@ -1,18 +1,18 @@
 # Windows Testing with DeviceRunners CLI
 
 
-This guide covers testing Windows applications using the DeviceRunners CLI tool. The tool supports both packaged (.msix) and unpackaged (.exe) Windows applications.
+This guide covers testing Windows applications using the DeviceRunners CLI tool. The tool supports three modes: packaged (.msix), loose-file MSIX (folder), and unpackaged (.exe) Windows applications.
 
 ## Running Tests
 
-1. Build the app for testing:  
+1. Build or publish the app for testing:  
    ```
-   dotnet publish <path/to/app.csproj> -f net9.0-windows10.0.19041.0 -c Release
+   dotnet build <path/to/app.csproj> -f net10.0-windows10.0.19041.0 -c Release
    ```
 
 2. Run the tests:  
    ```
-   device-runners windows test --app <path/to/app.[msix|exe]> --results-directory <path/to/output>
+   device-runners windows test --app <path/to/app.[msix|exe]|folder> --results-directory <path/to/output>
    ```
 
 3. View test results:  
@@ -20,7 +20,42 @@ This guide covers testing Windows applications using the DeviceRunners CLI tool.
    <path/to/output>/TestResults.xml
    ```
 
+## Input Modes
+
+| `--app` value | Mode | Certificate? | Build step |
+|---|---|---|---|
+| `path/to/app.msix` | Packaged MSIX | Yes | `dotnet publish` |
+| `path/to/build-output/` | Loose-file MSIX | No | `dotnet build` |
+| `path/to/AppxManifest.xml` | Loose-file MSIX | No | `dotnet build` |
+| `path/to/app.exe` | Unpackaged executable | No | `dotnet publish -p:WindowsPackageType=None` |
+
 ## Complete Examples
+
+### Testing with Loose-File MSIX Layout (Recommended for Development)
+
+The fastest way to test — just `dotnet build`, no publish or certificate needed. Requires **Windows Developer Mode** enabled on the machine.
+
+```pwsh
+# Build the app (no publish needed)
+dotnet build sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj `
+  -f net10.0-windows10.0.19041.0 `
+  -c Release `
+  -p:TestingMode=NonInteractiveVisual
+
+# Run tests from the build output folder
+device-runners windows test `
+  --app artifacts/bin/DeviceTestingKitApp.DeviceTests/release_net10.0-windows10.0.19041.0 `
+  --results-directory artifacts/test-results `
+  --logger trx
+```
+
+The CLI detects the folder contains an `AppxManifest.xml` and uses the bundled `winapp.exe` to:
+1. Register the app from loose files (no MSIX package needed)
+2. Launch the app via COM activation
+3. Collect test results via TCP
+4. Terminate and unregister the development package
+
+> **Note:** On CI, the Windows App Runtime framework must be installed from the NuGet cache before running. See [CI Pipeline Configuration](ci-pipeline.md) for details.
 
 ### Testing a Packaged Application
 
@@ -35,7 +70,7 @@ $fingerprint = ($certResult | ConvertFrom-Json).Thumbprint
 
 # Build the packaged app
 dotnet publish sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj `
-  -f net9.0-windows10.0.19041.0 `
+  -f net10.0-windows10.0.19041.0 `
   -c Release `
   -p:AppxPackageSigningEnabled=true `
   -p:PackageCertificateThumbprint=$fingerprint `
@@ -45,10 +80,8 @@ dotnet publish sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.D
 device-runners windows cert uninstall --fingerprint $fingerprint
 
 # Run tests (the CLI tool will handle certificate installation automatically)
-$msix = "sample\test\DeviceTestingKitApp.DeviceTests\bin\Release\net9.0-windows10.0.19041.0\win10-x64\AppPackages\DeviceTestingKitApp.DeviceTests_1.0.0.1_Test\DeviceTestingKitApp.DeviceTests_1.0.0.1_x64.msix"
-device-runners windows test --app $msix --results-directory artifacts/test-results
-
-# Test result file will be: artifacts/test-results/TestResults.xml
+$msix = (Get-ChildItem -Recurse -Filter "*.msix" -Path "artifacts" | Select-Object -First 1).FullName
+device-runners windows test --app $msix --results-directory artifacts/test-results --logger trx
 ```
 
 ### Testing an Unpackaged Application
@@ -56,13 +89,14 @@ device-runners windows test --app $msix --results-directory artifacts/test-resul
 ```pwsh
 # Build the unpackaged app  
 dotnet publish sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj `
-  -f net9.0-windows10.0.19041.0 `
+  -f net10.0-windows10.0.19041.0 `
   -c Release `
-  -p:WindowsPackageType=None
+  -p:WindowsPackageType=None `
+  --output artifacts/publish
 
 # Run tests
-$exe = "sample\test\DeviceTestingKitApp.DeviceTests\bin\Release\net9.0-windows10.0.19041.0\win10-x64\DeviceTestingKitApp.DeviceTests.exe"
-device-runners windows test --app $exe --results-directory artifacts/test-results
-
-# Test result file will be: artifacts/test-results/TestResults.xml
+device-runners windows test `
+  --app artifacts/publish/DeviceTestingKitApp.DeviceTests.exe `
+  --results-directory artifacts/test-results `
+  --logger trx
 ```

--- a/docs/articles/devicerunners-cli-test-workflow.md
+++ b/docs/articles/devicerunners-cli-test-workflow.md
@@ -69,6 +69,25 @@ Post-test cleanup and result processing:
 1. Terminates the application process if still running
 2. Preserves test results for analysis
 
+#### Loose-File MSIX Layout (folder or AppxManifest.xml)
+
+This mode uses the bundled `winapp.exe` tool to register a packaged app directly from the build output folder — no `.msix` file or certificate needed. Requires **Windows Developer Mode** and the **Windows App Runtime framework** to be installed.
+
+**Preparation:**
+1. Detects that `--app` points to a folder containing `AppxManifest.xml` (or a manifest file directly)
+2. Resolves the input folder and manifest path
+
+**Execution:**
+1. Invokes `winapp.exe run --detach --json` to register the app from loose files and launch it
+2. Parses the JSON output to get the launched process ID (PID)
+3. Starts TCP listener on specified port for test results
+4. Monitors test progress with configurable timeouts
+
+**Cleanup:**
+1. Terminates the application process by PID if still running
+2. Invokes `winapp.exe unregister` to remove the development package registration
+3. Preserves test results for analysis
+
 ### Android Test Workflow
 
 **Preparation:**
@@ -186,9 +205,10 @@ device-runners [platform] test \
 ### Platform-Specific Options
 
 #### Windows-Specific
-- **Certificate Management**: Automatic detection and installation
-- **Dependency Handling**: Automatic installation of required dependencies
-- **Package vs. Executable**: Automatic detection and appropriate handling
+- **Certificate Management**: Automatic detection and installation (MSIX mode)
+- **Dependency Handling**: Automatic installation of required dependencies (MSIX mode)
+- **Loose-File Registration**: Uses bundled `winapp.exe` for folder-based testing (requires Developer Mode)
+- **Package vs. Executable vs. Folder**: Automatic detection and appropriate handling
 
 #### Android-Specific  
 - **Device Targeting**: Specify target device or emulator
@@ -207,7 +227,7 @@ device-runners [platform] test \
 - Check application actually attempts to connect to TCP port
 
 ### Installation Failures
-- **Windows**: Verify certificate installation and dependency availability
+- **Windows**: Verify certificate installation and dependency availability. For loose-file MSIX, ensure Windows Developer Mode is enabled and the Windows App Runtime framework is installed.
 - **Android**: Check device connectivity and storage space
 - **macOS**: Verify app bundle format and system permissions
 


### PR DESCRIPTION
Updates documentation to cover the loose-file MSIX testing feature added in #94.

### Files updated

- **cli-device-runner-for-windows-using-devicerunners-cli.md** — input modes table, loose-file example, TFM update to net10.0
- **devicerunners-cli-test-workflow.md** — loose-file MSIX workflow section, winapp.exe registration/cleanup docs
- **ci-pipeline.md** — test-tcp-windows-loose entries in file reference and platform matrix