### PR TITLE
feat: Add NUnit support to Blazor browser test runner with WASM fixes

### DIFF
--- a/DeviceRunners.slnx
+++ b/DeviceRunners.slnx
@@ -12,6 +12,7 @@
     <Project Path="sample/test/DeviceTestingKitApp.Library.NUnitTests/DeviceTestingKitApp.Library.NUnitTests.csproj" />
     <Project Path="sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/DeviceTestingKitApp.MauiLibrary.XunitTests.csproj" />
     <Project Path="sample/test/DeviceTestingKitApp.BrowserTests/DeviceTestingKitApp.BrowserTests.csproj" />
+    <Project Path="sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/DeviceTestingKitApp.BlazorLibrary.NUnitTests.csproj" />
     <Project Path="sample/test/DeviceTestingKitApp.BlazorLibrary.XunitTests/DeviceTestingKitApp.BlazorLibrary.XunitTests.csproj" />
   </Folder>
   <Folder Name="/src/">

--- a/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/Controls/CounterViewModelTests.cs
+++ b/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/Controls/CounterViewModelTests.cs
@@ -1,0 +1,74 @@
+using DeviceTestingKitApp.ViewModels;
+
+namespace DeviceTestingKitApp.BlazorLibrary.NUnitTests.Controls;
+
+public class CounterViewModelTests
+{
+	[Test]
+	public void InitialStateIsCorrect()
+	{
+		var vm = new CounterViewModel();
+
+		Assert.That(vm.Count, Is.EqualTo(0));
+	}
+
+	[Test]
+	public void SingleIncrementIncrementsByOne()
+	{
+		var vm = new CounterViewModel();
+
+		vm.IncrementCommand.Execute(null);
+
+		Assert.That(vm.Count, Is.EqualTo(1));
+	}
+
+	[Test]
+	[TestCase(1)]
+	[TestCase(2)]
+	[TestCase(3)]
+	public void IncrementsIncrementCorrectly(int executeCount)
+	{
+		var vm = new CounterViewModel();
+
+		for (var i = 0; i < executeCount; i++)
+		{
+			vm.IncrementCommand.Execute(null);
+		}
+
+		Assert.That(vm.Count, Is.EqualTo(executeCount));
+	}
+
+	[Test]
+	public void UpdatingCountPropertyTriggersPropertyChanged()
+	{
+		var vm = new CounterViewModel();
+
+		var eventTrigger = 0;
+		vm.PropertyChanged += (sender, args) =>
+		{
+			Assert.That(args.PropertyName, Is.EqualTo(nameof(vm.Count)));
+			eventTrigger++;
+		};
+
+		vm.Count = 5;
+
+		Assert.That(eventTrigger, Is.EqualTo(1));
+	}
+
+	[Test]
+	public void ExecutingCommandTriggersPropertyChanged()
+	{
+		var vm = new CounterViewModel();
+
+		var eventTrigger = 0;
+		vm.PropertyChanged += (sender, args) =>
+		{
+			Assert.That(args.PropertyName, Is.EqualTo(nameof(vm.Count)));
+			eventTrigger++;
+		};
+
+		vm.IncrementCommand.Execute(null);
+
+		Assert.That(eventTrigger, Is.EqualTo(1));
+	}
+}

--- a/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/DeviceTestingKitApp.BlazorLibrary.NUnitTests.csproj
+++ b/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/DeviceTestingKitApp.BlazorLibrary.NUnitTests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <DefineConstants Condition="'$(CI)' != 'true' And '$(TF_BUILD)' != 'True'">INCLUDE_FAILING_TESTS</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DeviceTestingKitApp.BlazorLibrary\DeviceTestingKitApp.BlazorLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/Formatters/CounterValueFormatterTests.cs
+++ b/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/Formatters/CounterValueFormatterTests.cs
@@ -1,0 +1,35 @@
+using DeviceTestingKitApp.Formatters;
+
+namespace DeviceTestingKitApp.BlazorLibrary.NUnitTests.Formatters;
+
+public class CounterValueFormatterTests
+{
+	[Test]
+	public void Format_Zero_ReturnsClickMe()
+	{
+		Assert.That(CounterValueFormatter.Format(0), Is.EqualTo("Click me!"));
+	}
+
+	[Test]
+	public void Format_One_ReturnsSingular()
+	{
+		Assert.That(CounterValueFormatter.Format(1), Is.EqualTo("Clicked 1 time"));
+	}
+
+	[Test]
+	[TestCase(2, "Clicked 2 times")]
+	[TestCase(5, "Clicked 5 times")]
+	[TestCase(100, "Clicked 100 times")]
+	public void Format_Multiple_ReturnsPlural(int count, string expected)
+	{
+		Assert.That(CounterValueFormatter.Format(count), Is.EqualTo(expected));
+	}
+
+	[Test]
+	[TestCase(-1, "Clicked -1 times")]
+	[TestCase(2147483647, "Clicked 2147483647 times")]
+	public void Format_EdgeCases_ReturnsPlural(int count, string expected)
+	{
+		Assert.That(CounterValueFormatter.Format(count), Is.EqualTo(expected));
+	}
+}

--- a/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/UnitTests.cs
@@ -1,0 +1,25 @@
+namespace DeviceTestingKitApp.BlazorLibrary.NUnitTests;
+
+public class UnitTests
+{
+	[Test]
+	public void SuccessfulTest()
+	{
+		var value = true;
+		Assert.That(value, Is.True);
+	}
+
+	[Test]
+	[Ignore("This test is skipped.")]
+	public void SkippedTest()
+	{
+	}
+
+#if INCLUDE_FAILING_TESTS
+	[Test]
+	public void FailingTest()
+	{
+		throw new Exception("This is meant to fail.");
+	}
+#endif
+}

--- a/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/Usings.cs
+++ b/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/sample/test/DeviceTestingKitApp.BrowserTests/DeviceTestingKitApp.BrowserTests.csproj
+++ b/sample/test/DeviceTestingKitApp.BrowserTests/DeviceTestingKitApp.BrowserTests.csproj
@@ -15,12 +15,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="NUnit" />
     <PackageReference Include="xunit" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\DeviceRunners.VisualRunners.Blazor\DeviceRunners.VisualRunners.Blazor.csproj" />
+    <ProjectReference Include="..\..\..\src\DeviceRunners.VisualRunners.NUnit\DeviceRunners.VisualRunners.NUnit.csproj" />
     <ProjectReference Include="..\..\..\src\DeviceRunners.VisualRunners.Xunit\DeviceRunners.VisualRunners.Xunit.csproj" />
+    <ProjectReference Include="..\DeviceTestingKitApp.BlazorLibrary.NUnitTests\DeviceTestingKitApp.BlazorLibrary.NUnitTests.csproj" />
     <ProjectReference Include="..\DeviceTestingKitApp.BlazorLibrary.XunitTests\DeviceTestingKitApp.BlazorLibrary.XunitTests.csproj" />
   </ItemGroup>
 

--- a/sample/test/DeviceTestingKitApp.BrowserTests/Program.cs
+++ b/sample/test/DeviceTestingKitApp.BrowserTests/Program.cs
@@ -9,8 +9,10 @@ builder.RootComponents.Add<TestRunnerApp>("#app");
 
 builder.UseVisualTestRunner(conf => conf
 	.AddXunit(useReflection: true)
+	.AddNUnit()
 	.AddTestAssembly(typeof(DeviceTestingKitApp.BrowserTests.UnitTests).Assembly)
 	.AddTestAssemblies(typeof(DeviceTestingKitApp.BlazorLibrary.XunitTests.UnitTests).Assembly)
+	.AddTestAssemblies(typeof(DeviceTestingKitApp.BlazorLibrary.NUnitTests.UnitTests).Assembly)
 	.AddConsoleResultChannel());
 
 await builder.Build().RunAsync();

--- a/src/DeviceRunners.VisualRunners.NUnit/NUnitTestDiscoverer.cs
+++ b/src/DeviceRunners.VisualRunners.NUnit/NUnitTestDiscoverer.cs
@@ -18,6 +18,7 @@ public class NUnitTestDiscoverer : ITestDiscoverer
 		_diagnosticsManager = diagnosticsManager;
 		_testAssemblies = options.TestAssemblies.ToArray();
 	}
+
 	public Task<IReadOnlyList<ITestAssemblyInfo>> DiscoverAsync(CancellationToken cancellationToken = default) =>
 		AsyncUtils.RunAsync(() => Discover(cancellationToken));
 
@@ -32,15 +33,35 @@ public class NUnitTestDiscoverer : ITestDiscoverer
 				if (cancellationToken.IsCancellationRequested)
 					break;
 
-				var assemblyFileName = FileSystemUtils.GetAssemblyFileName(assm);
+				var assemblyFileName = GetAssemblyFileName(assm);
 
-				// TODO: configuration
-				var configuration = new Dictionary<string, object>();
+				// Provide a WorkDirectory to prevent NUnit from calling
+				// Directory.GetCurrentDirectory() which may fail on some platforms.
+				// Set RunOnMainThread=true to use MainThreadWorkItemDispatcher which
+				// executes tests inline without spawning threads — required for
+				// single-threaded environments like WASM where Thread.Start() throws.
+				// Set SynchronousEvents=true to avoid creating an EventPump thread.
+				var configuration = new Dictionary<string, object>
+				{
+					["WorkDirectory"] = ".",
+					["RunOnMainThread"] = true,
+					["SynchronousEvents"] = true
+				};
 
 				try
 				{
 					var builder = new DefaultTestAssemblyBuilder();
 					var nunitTestAssembly = (TestAssembly)builder.Build(assm, configuration);
+
+					// Check if NUnit marked the assembly as invalid (e.g. no fixtures found
+					// due to ReflectionTypeLoadException on WASM)
+					if (nunitTestAssembly.RunState == RunState.NotRunnable)
+					{
+						var reason = nunitTestAssembly.Properties.Get(PropertyNames.SkipReason) as string;
+						_diagnosticsManager?.PostDiagnosticMessage(
+							$"NUnit marked assembly '{assemblyFileName}' as not runnable: {reason}");
+						continue;
+					}
 
 					var testAssembly = new NUnitTestAssemblyInfo(assemblyFileName, nunitTestAssembly, configuration);
 					var testCases = GetChildTests(nunitTestAssembly)
@@ -51,6 +72,11 @@ public class NUnitTestDiscoverer : ITestDiscoverer
 					{
 						testAssembly.TestCases.AddRange(testCases);
 						result.Add(testAssembly);
+					}
+					else
+					{
+						_diagnosticsManager?.PostDiagnosticMessage(
+							$"NUnit found 0 test cases in assembly '{assemblyFileName}' (RunState={nunitTestAssembly.RunState}, HasChildren={nunitTestAssembly.HasChildren}, TestCount={nunitTestAssembly.TestCaseCount})");
 					}
 				}
 				catch (Exception ex)
@@ -65,6 +91,16 @@ public class NUnitTestDiscoverer : ITestDiscoverer
 		}
 
 		return result;
+	}
+
+	static string GetAssemblyFileName(Assembly assembly)
+	{
+		// On WASM, Assembly.Location is empty string. Use the assembly name as fallback.
+		var location = assembly.Location;
+		if (!string.IsNullOrEmpty(location))
+			return location;
+
+		return assembly.GetName().Name + ".dll";
 	}
 
 	static IEnumerable<ITest> GetChildTests(ITest test)

--- a/src/DeviceRunners.VisualRunners.NUnit/NUnitTestDiscoverer.cs
+++ b/src/DeviceRunners.VisualRunners.NUnit/NUnitTestDiscoverer.cs
@@ -33,35 +33,23 @@ public class NUnitTestDiscoverer : ITestDiscoverer
 				if (cancellationToken.IsCancellationRequested)
 					break;
 
-				var assemblyFileName = GetAssemblyFileName(assm);
+				var assemblyFileName = FileSystemUtils.GetAssemblyFileName(assm);
 
-				// Provide a WorkDirectory to prevent NUnit from calling
-				// Directory.GetCurrentDirectory() which may fail on some platforms.
-				// Set RunOnMainThread=true to use MainThreadWorkItemDispatcher which
-				// executes tests inline without spawning threads — required for
-				// single-threaded environments like WASM where Thread.Start() throws.
-				// Set SynchronousEvents=true to avoid creating an EventPump thread.
-				var configuration = new Dictionary<string, object>
+				var configuration = new Dictionary<string, object>();
+
+				// On WASM (single-threaded), NUnit's dispatchers and EventPump
+				// create threads which throw PlatformNotSupportedException.
+				if (OperatingSystem.IsBrowser())
 				{
-					["WorkDirectory"] = ".",
-					["RunOnMainThread"] = true,
-					["SynchronousEvents"] = true
-				};
+					configuration["WorkDirectory"] = ".";
+					configuration["RunOnMainThread"] = true;
+					configuration["SynchronousEvents"] = true;
+				}
 
 				try
 				{
 					var builder = new DefaultTestAssemblyBuilder();
 					var nunitTestAssembly = (TestAssembly)builder.Build(assm, configuration);
-
-					// Check if NUnit marked the assembly as invalid (e.g. no fixtures found
-					// due to ReflectionTypeLoadException on WASM)
-					if (nunitTestAssembly.RunState == RunState.NotRunnable)
-					{
-						var reason = nunitTestAssembly.Properties.Get(PropertyNames.SkipReason) as string;
-						_diagnosticsManager?.PostDiagnosticMessage(
-							$"NUnit marked assembly '{assemblyFileName}' as not runnable: {reason}");
-						continue;
-					}
 
 					var testAssembly = new NUnitTestAssemblyInfo(assemblyFileName, nunitTestAssembly, configuration);
 					var testCases = GetChildTests(nunitTestAssembly)
@@ -72,11 +60,6 @@ public class NUnitTestDiscoverer : ITestDiscoverer
 					{
 						testAssembly.TestCases.AddRange(testCases);
 						result.Add(testAssembly);
-					}
-					else
-					{
-						_diagnosticsManager?.PostDiagnosticMessage(
-							$"NUnit found 0 test cases in assembly '{assemblyFileName}' (RunState={nunitTestAssembly.RunState}, HasChildren={nunitTestAssembly.HasChildren}, TestCount={nunitTestAssembly.TestCaseCount})");
 					}
 				}
 				catch (Exception ex)
@@ -91,16 +74,6 @@ public class NUnitTestDiscoverer : ITestDiscoverer
 		}
 
 		return result;
-	}
-
-	static string GetAssemblyFileName(Assembly assembly)
-	{
-		// On WASM, Assembly.Location is empty string. Use the assembly name as fallback.
-		var location = assembly.Location;
-		if (!string.IsNullOrEmpty(location))
-			return location;
-
-		return assembly.GetName().Name + ".dll";
 	}
 
 	static IEnumerable<ITest> GetChildTests(ITest test)

--- a/src/DeviceRunners.VisualRunners.Xunit/XunitReflectionTestDiscoverer.cs
+++ b/src/DeviceRunners.VisualRunners.Xunit/XunitReflectionTestDiscoverer.cs
@@ -31,7 +31,7 @@ public class XunitReflectionTestDiscoverer : ITestDiscoverer
 			if (cancellationToken.IsCancellationRequested)
 				break;
 
-			var assemblyFileName = assembly.GetName().Name + ".dll";
+			var assemblyFileName = FileSystemUtils.GetAssemblyFileName(assembly);
 			var configuration = new TestAssemblyConfiguration
 			{
 				ShadowCopy = false,

--- a/src/DeviceRunners.VisualRunners/Utils/FileSystemUtils.cs
+++ b/src/DeviceRunners.VisualRunners/Utils/FileSystemUtils.cs
@@ -98,7 +98,13 @@ public class FileSystemUtils
 			File.Create(path).Close();
 		return path;
 #else
-		return assm.Location;
+		// On WASM (and other platforms without filesystem-backed assemblies),
+		// Assembly.Location is empty. Fall back to the assembly name.
+		var location = assm.Location;
+		if (!string.IsNullOrEmpty(location))
+			return location;
+
+		return filename;
 #endif
 	}
 


### PR DESCRIPTION
## Summary

Add NUnit test framework support to the Blazor WebAssembly browser test runner, with fixes to make NUnit discovery and execution work on single-threaded WASM environments.

## Changes

### New: NUnit Browser Test Library
- **`DeviceTestingKitApp.BlazorLibrary.NUnitTests`** — NUnit test library for Blazor (net9.0)
  - `UnitTests.cs` — pass/skip/fail pattern matching existing samples
  - `Controls/CounterViewModelTests.cs` — tests for CounterViewModel
  - `Formatters/CounterValueFormatterTests.cs` — tests for CounterValueFormatter

### NUnit WASM Compatibility Fixes (scoped to `OperatingSystem.IsBrowser()`)
On WASM, NUnit internally creates threads in two places that throw `PlatformNotSupportedException`:
1. `SimpleWorkItemDispatcher.Start()` — calls `new Thread().Start()`
2. `EventPump.Start()` — creates a pump thread

Fix: When running in a browser, configure NUnit with:
- `RunOnMainThread=true` → uses `MainThreadWorkItemDispatcher` (executes inline, no threads)
- `SynchronousEvents=true` → bypasses EventPump thread
- `WorkDirectory=.` → avoids `Directory.GetCurrentDirectory()` calls

These settings are **only applied on WASM** — non-WASM platforms retain full parallelism and async event delivery.

### Shared Assembly Filename Logic
- Fixed `FileSystemUtils.GetAssemblyFileName` to handle empty `Assembly.Location` (WASM) by falling back to assembly name
- Both xunit reflection discoverer and NUnit discoverer now use `FileSystemUtils.GetAssemblyFileName` instead of inline duplicates

### Wiring
- BrowserTests `Program.cs`: Added `.AddNUnit()` and NUnit test assembly registration
- BrowserTests `.csproj`: Added NUnit package reference and `VisualRunners.NUnit` project reference
- `DeviceRunners.slnx`: Added new test project

## Testing
- All 179 unit tests pass
- BrowserTests builds successfully with both xunit and NUnit wired up
- DeviceTests already had NUnit via `.AddNUnit()` (unchanged)