### PR TITLE
Fix app discovery when ApplicationTitle differs from AssemblyName

### DIFF
--- a/.azure/templates/test-xharness-ios.yml
+++ b/.azure/templates/test-xharness-ios.yml
@@ -46,6 +46,15 @@ jobs:
               /bl:./artifacts/logs/msbuild-publish.binlog
           displayName: 'Publish App'
         - script: |
+            OUTPUT_DIR="artifacts/bin/DeviceTestingKitApp.DeviceTests/$(TEST_CONFIGURATION)_$(TEST_TARGET_FRAMEWORK)_$(TEST_RUNTIME_IDENTIFIER)"
+            APP_PATH=$(find "$OUTPUT_DIR" -maxdepth 1 -name "*.app" -type d | head -1)
+            if [ -z "$APP_PATH" ]; then
+              echo "##vso[task.logissue type=error]No .app bundle found in $OUTPUT_DIR"
+              exit 1
+            fi
+            echo "##vso[task.setvariable variable=APP_PATH]$APP_PATH"
+          displayName: 'Discover App Bundle'
+        - script: |
             for i in $(seq 1 3)
             do
               dotnet xharness apple test \
@@ -53,7 +62,7 @@ jobs:
                 --device "$(SIMULATOR_UDID)" \
                 --timeout="00:10:00" \
                 --launch-timeout=00:10:00 \
-                --app artifacts/bin/DeviceTestingKitApp.DeviceTests/$(TEST_CONFIGURATION)_$(TEST_TARGET_FRAMEWORK)_$(TEST_RUNTIME_IDENTIFIER)/DeviceTestingKitApp.DeviceTests.app \
+                --app "$(APP_PATH)" \
                 --output-directory artifacts/test-results \
               && code=0 && break || code=$? && echo "Attempt $i failed (exit $code), rebooting simulator..." && dotnet apple simulator shutdown "$(SIMULATOR_UDID)" && sleep 5 && dotnet apple simulator boot "$(SIMULATOR_UDID)" --wait && sleep 30
             done

--- a/.azure/templates/test-xharness-maccatalyst.yml
+++ b/.azure/templates/test-xharness-maccatalyst.yml
@@ -37,11 +37,20 @@ jobs:
               /bl:./artifacts/logs/msbuild-publish.binlog
           displayName: 'Publish App'
         - script: |
+            OUTPUT_DIR="artifacts/bin/DeviceTestingKitApp.DeviceTests/$(TEST_CONFIGURATION)_$(TEST_TARGET_FRAMEWORK)_$(TEST_RUNTIME_IDENTIFIER)"
+            APP_PATH=$(find "$OUTPUT_DIR" -maxdepth 1 -name "*.app" -type d | head -1)
+            if [ -z "$APP_PATH" ]; then
+              echo "##vso[task.logissue type=error]No .app bundle found in $OUTPUT_DIR"
+              exit 1
+            fi
+            echo "##vso[task.setvariable variable=APP_PATH]$APP_PATH"
+          displayName: 'Discover App Bundle'
+        - script: |
             dotnet xharness apple test \
               --target maccatalyst \
               --timeout="00:02:00" \
               --launch-timeout=00:06:00 \
-              --app artifacts/bin/DeviceTestingKitApp.DeviceTests/$(TEST_CONFIGURATION)_$(TEST_TARGET_FRAMEWORK)_$(TEST_RUNTIME_IDENTIFIER)/DeviceTestingKitApp.DeviceTests.app \
+              --app "$(APP_PATH)" \
               --output-directory artifacts/test-results
           displayName: 'Run Tests'
         - script: |

--- a/.github/workflows/test-xharness-ios/action.yml
+++ b/.github/workflows/test-xharness-ios/action.yml
@@ -51,6 +51,17 @@ runs:
           -c ${{ inputs.configuration }} \
           -p:TestingMode=XHarness \
           /bl:./artifacts/logs/msbuild-publish.binlog
+    - name: Discover App Bundle
+      id: app
+      shell: bash
+      run: |
+        OUTPUT_DIR="artifacts/bin/DeviceTestingKitApp.DeviceTests/${{ inputs.configuration }}_${{ inputs.target-framework }}_${{ inputs.runtime-identifier }}"
+        APP_PATH=$(find "$OUTPUT_DIR" -maxdepth 1 -name "*.app" -type d | head -1)
+        if [ -z "$APP_PATH" ]; then
+          echo "::error::No .app bundle found in $OUTPUT_DIR"
+          exit 1
+        fi
+        echo "path=$APP_PATH" >> "$GITHUB_OUTPUT"
     - name: Run Tests
       shell: bash
       run: |
@@ -61,7 +72,7 @@ runs:
             --device "${{ steps.simulator.outputs.udid }}" \
             --timeout="00:10:00" \
             --launch-timeout=00:10:00 \
-            --app artifacts/bin/DeviceTestingKitApp.DeviceTests/${{ inputs.configuration }}_${{ inputs.target-framework }}_${{ inputs.runtime-identifier }}/DeviceTestingKitApp.DeviceTests.app \
+            --app "${{ steps.app.outputs.path }}" \
             --output-directory artifacts/test-results \
           && code=0 && break || code=$? && echo "Attempt $i failed (exit $code), rebooting simulator..." && dotnet apple simulator shutdown "${{ steps.simulator.outputs.udid }}" && sleep 5 && dotnet apple simulator boot "${{ steps.simulator.outputs.udid }}" --wait && sleep 30
         done

--- a/.github/workflows/test-xharness-maccatalyst/action.yml
+++ b/.github/workflows/test-xharness-maccatalyst/action.yml
@@ -36,6 +36,17 @@ runs:
           -c ${{ inputs.configuration }} \
           -p:TestingMode=XHarness \
           /bl:./artifacts/logs/msbuild-publish.binlog
+    - name: Discover App Bundle
+      id: app
+      shell: bash
+      run: |
+        OUTPUT_DIR="artifacts/bin/DeviceTestingKitApp.DeviceTests/${{ inputs.configuration }}_${{ inputs.target-framework }}_${{ inputs.runtime-identifier }}"
+        APP_PATH=$(find "$OUTPUT_DIR" -maxdepth 1 -name "*.app" -type d | head -1)
+        if [ -z "$APP_PATH" ]; then
+          echo "::error::No .app bundle found in $OUTPUT_DIR"
+          exit 1
+        fi
+        echo "path=$APP_PATH" >> "$GITHUB_OUTPUT"
     - name: Run Tests
       shell: bash
       run: |
@@ -43,7 +54,7 @@ runs:
           --target maccatalyst \
           --timeout="00:02:00" \
           --launch-timeout=00:06:00 \
-          --app artifacts/bin/DeviceTestingKitApp.DeviceTests/${{ inputs.configuration }}_${{ inputs.target-framework }}_${{ inputs.runtime-identifier }}/DeviceTestingKitApp.DeviceTests.app \
+          --app "${{ steps.app.outputs.path }}" \
           --output-directory artifacts/test-results
     - name: Clean up build artifacts before upload
       if: always()

--- a/docs/articles/cli-device-runner-for-ios-using-devicerunners-cli.md
+++ b/docs/articles/cli-device-runner-for-ios-using-devicerunners-cli.md
@@ -35,7 +35,7 @@ dotnet build sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.Dev
 
 # Run tests
 device-runners ios test \
-  --app sample/test/DeviceTestingKitApp.DeviceTests/bin/Debug/net10.0-ios/iossimulator-arm64/DeviceTestingKitApp.DeviceTests.app \
+  --app "sample/test/DeviceTestingKitApp.DeviceTests/bin/Debug/net10.0-ios/iossimulator-arm64/DeviceRunners Tests.app" \
   --results-directory artifacts/test-results
 
 # Test result file will be: artifacts/test-results/TestResults.xml

--- a/docs/articles/cli-device-runner-for-ios-using-xharness.md
+++ b/docs/articles/cli-device-runner-for-ios-using-xharness.md
@@ -29,7 +29,7 @@ dotnet build sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.Dev
 
 xharness apple test \
   --target ios-simulator-64 \
-  --app sample/test/DeviceTestingKitApp.DeviceTests/bin/Debug/net9.0-ios/iossimulator-arm64/DeviceTestingKitApp.DeviceTests.app \
+  --app "sample/test/DeviceTestingKitApp.DeviceTests/bin/Debug/net9.0-ios/iossimulator-arm64/DeviceRunners Tests.app" \
   --output-directory artifacts
 
 # test result file will be artifacts/xunit-test-ios-simulator-64-########_######.xml

--- a/docs/articles/cli-device-runner-for-mac-catalyst-using-xharness.md
+++ b/docs/articles/cli-device-runner-for-mac-catalyst-using-xharness.md
@@ -29,7 +29,7 @@ dotnet build sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.Dev
 
 xharness apple test \
   --target maccatalyst \
-  --app sample/test/DeviceTestingKitApp.DeviceTests/bin/Debug/net9.0-maccatalyst/maccatalyst-arm64/DeviceTestingKitApp.DeviceTests.app \
+  --app "sample/test/DeviceTestingKitApp.DeviceTests/bin/Debug/net9.0-maccatalyst/maccatalyst-arm64/DeviceRunners Tests.app" \
   --output-directory artifacts
 
 # test result file will be artifacts/xunit-test-maccatalyst-########_######.xml

--- a/docs/articles/cli-device-runner-for-macos-using-devicerunners-cli.md
+++ b/docs/articles/cli-device-runner-for-macos-using-devicerunners-cli.md
@@ -35,7 +35,7 @@ dotnet publish sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.D
 
 # Run tests
 device-runners macos test \
-  --app sample/test/DeviceTestingKitApp.DeviceTests/bin/Release/net10.0-maccatalyst/maccatalyst-arm64/publish/DeviceTestingKitApp.DeviceTests.app \
+  --app "sample/test/DeviceTestingKitApp.DeviceTests/bin/Release/net10.0-maccatalyst/maccatalyst-arm64/publish/DeviceRunners Tests.app" \
   --results-directory artifacts/test-results
 
 # Test result file will be: artifacts/test-results/TestResults.xml

--- a/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
@@ -20,7 +20,7 @@
     <DefineConstants Condition="'$(TestingMode)' == 'XHarness'">$(DefineConstants);MODE_XHARNESS</DefineConstants>
 
     <!-- Display name -->
-    <ApplicationTitle>DeviceTestingKitApp.DeviceTests</ApplicationTitle>
+    <ApplicationTitle>DeviceRunners Tests</ApplicationTitle>
 
     <!-- App Identifier -->
     <ApplicationId>com.companyname.devicetestingkitapp.devicetests</ApplicationId>

--- a/src/DeviceRunners.Testing.Targets/build/DeviceRunners.Testing.Targets.targets
+++ b/src/DeviceRunners.Testing.Targets/build/DeviceRunners.Testing.Targets.targets
@@ -153,7 +153,11 @@
   <Target Name="_DeviceRunnersiOSArgs"
           Condition="'$(_DeviceRunnersPlatform)' == 'ios'">
     <PropertyGroup>
-      <_DeviceRunnersAppPath>$([System.IO.Directory]::GetDirectories('$(OutputPath)', '$(AssemblyName).app'))</_DeviceRunnersAppPath>
+      <!-- MAUI names the .app bundle after $(ApplicationTitle), not $(AssemblyName).
+           Try ApplicationTitle first, then AssemblyName, then wildcard as fallback. -->
+      <_DeviceRunnersAppPath Condition="'$(ApplicationTitle)' != ''">$([System.IO.Directory]::GetDirectories('$(OutputPath)', '$(ApplicationTitle).app'))</_DeviceRunnersAppPath>
+      <_DeviceRunnersAppPath Condition="'$(_DeviceRunnersAppPath)' == ''">$([System.IO.Directory]::GetDirectories('$(OutputPath)', '$(AssemblyName).app'))</_DeviceRunnersAppPath>
+      <_DeviceRunnersAppPath Condition="'$(_DeviceRunnersAppPath)' == ''">$([System.IO.Directory]::GetDirectories('$(OutputPath)', '*.app'))</_DeviceRunnersAppPath>
       <_DeviceRunnersAppPath>$(_DeviceRunnersAppPath.TrimEnd('\').TrimEnd('/'))</_DeviceRunnersAppPath>
     </PropertyGroup>
     <Error Text="No .app bundle found in '$(OutputPath)'. Make sure the project builds successfully."
@@ -169,7 +173,11 @@
   <Target Name="_DeviceRunnersMacOSArgs"
           Condition="'$(_DeviceRunnersPlatform)' == 'maccatalyst'">
     <PropertyGroup>
-      <_DeviceRunnersAppPath>$([System.IO.Directory]::GetDirectories('$(OutputPath)', '$(AssemblyName).app'))</_DeviceRunnersAppPath>
+      <!-- MAUI names the .app bundle after $(ApplicationTitle), not $(AssemblyName).
+           Try ApplicationTitle first, then AssemblyName, then wildcard as fallback. -->
+      <_DeviceRunnersAppPath Condition="'$(ApplicationTitle)' != ''">$([System.IO.Directory]::GetDirectories('$(OutputPath)', '$(ApplicationTitle).app'))</_DeviceRunnersAppPath>
+      <_DeviceRunnersAppPath Condition="'$(_DeviceRunnersAppPath)' == ''">$([System.IO.Directory]::GetDirectories('$(OutputPath)', '$(AssemblyName).app'))</_DeviceRunnersAppPath>
+      <_DeviceRunnersAppPath Condition="'$(_DeviceRunnersAppPath)' == ''">$([System.IO.Directory]::GetDirectories('$(OutputPath)', '*.app'))</_DeviceRunnersAppPath>
       <_DeviceRunnersAppPath>$(_DeviceRunnersAppPath.TrimEnd('\').TrimEnd('/'))</_DeviceRunnersAppPath>
     </PropertyGroup>
     <Error Text="No .app bundle found in '$(OutputPath)'. Make sure the project builds successfully."


### PR DESCRIPTION
## Summary

Fixes #131

MAUI SDK names the `.app` bundle after `$(ApplicationTitle)`, not `$(AssemblyName)`. When these differ, DeviceRunners could not find the bundle and failed with "No .app bundle found".

## Changes

Updated the `.app` discovery logic in `DeviceRunners.Testing.Targets.targets` for both iOS and macOS Catalyst targets. Discovery now tries in order:

1. `$(ApplicationTitle).app` — what MAUI produces
2. `$(AssemblyName).app` — backward compatibility
3. `*.app` wildcard — last resort fallback

## Testing

- If `ApplicationTitle` matches `AssemblyName`: behaves exactly as before (first check finds it)
- If `ApplicationTitle` differs: first check now correctly finds the bundle
- If neither matches (edge case): wildcard picks up whatever `.app` exists in the output directory