### PR TITLE
Add dotnet test --filter support for device tests

### DIFF
--- a/.azure/templates/test-dotnet-test-android.yml
+++ b/.azure/templates/test-dotnet-test-android.yml
@@ -75,6 +75,7 @@ jobs:
             -f $(TEST_TARGET_FRAMEWORK) \
             -c $(TEST_CONFIGURATION) \
             -p:AndroidSdkDirectory=$(ANDROID_SDK_ROOT) \
+            --filter "Category!=ExpectedFailure" \
             --logger "trx;LogFileName=test-results.trx" \
             /bl:./artifacts/logs/msbuild-test.binlog
         displayName: 'Run Tests'

--- a/.azure/templates/test-dotnet-test-ios.yml
+++ b/.azure/templates/test-dotnet-test-ios.yml
@@ -46,6 +46,7 @@ jobs:
             -r $(TEST_RUNTIME_IDENTIFIER) \
             -c $(TEST_CONFIGURATION) \
             -p:DeviceRunnersDevice=$(SIMULATOR_UDID) \
+            --filter "Category!=ExpectedFailure" \
             --logger "trx;LogFileName=test-results.trx" \
             /bl:./artifacts/logs/msbuild-test.binlog
         displayName: 'Run Tests'

--- a/.azure/templates/test-dotnet-test-macos.yml
+++ b/.azure/templates/test-dotnet-test-macos.yml
@@ -34,6 +34,7 @@ jobs:
             -f $(TEST_TARGET_FRAMEWORK) \
             -r $(TEST_RUNTIME_IDENTIFIER) \
             -c $(TEST_CONFIGURATION) \
+            --filter "Category!=ExpectedFailure" \
             --logger "trx;LogFileName=test-results.trx" \
             /bl:./artifacts/logs/msbuild-test.binlog
         displayName: 'Run Tests'

--- a/.azure/templates/test-dotnet-test-wasm.yml
+++ b/.azure/templates/test-dotnet-test-wasm.yml
@@ -21,6 +21,7 @@ jobs:
       - script: |
           dotnet test sample/test/DeviceTestingKitApp.BrowserTests/DeviceTestingKitApp.BrowserTests.csproj \
             -c $(TEST_CONFIGURATION) \
+            --filter "Category!=ExpectedFailure" \
             --logger "trx;LogFileName=test-results.trx" \
             /bl:./artifacts/logs/msbuild-test.binlog
         displayName: 'Run Tests'

--- a/.azure/templates/test-dotnet-test-windows-exe.yml
+++ b/.azure/templates/test-dotnet-test-windows-exe.yml
@@ -27,6 +27,7 @@ jobs:
             -f $(TEST_TARGET_FRAMEWORK) `
             -c $(TEST_CONFIGURATION) `
             -p:WindowsPackageType=None `
+            --filter "Category!=ExpectedFailure" `
             --logger "trx;LogFileName=test-results.trx" `
             /bl:./artifacts/logs/msbuild-test.binlog
         displayName: 'Run Tests'

--- a/.azure/templates/test-dotnet-test-windows.yml
+++ b/.azure/templates/test-dotnet-test-windows.yml
@@ -44,6 +44,7 @@ jobs:
           dotnet test sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj `
             -f $(TEST_TARGET_FRAMEWORK) `
             -c $(TEST_CONFIGURATION) `
+            --filter "Category!=ExpectedFailure" `
             --logger "trx;LogFileName=test-results.trx" `
             /bl:./artifacts/logs/msbuild-test.binlog
         displayName: 'Run Tests'

--- a/.azure/templates/test-tcp-android.yml
+++ b/.azure/templates/test-tcp-android.yml
@@ -90,6 +90,7 @@ jobs:
               -r $(TEST_RUNTIME_IDENTIFIER) \
               -c $(TEST_CONFIGURATION) \
               -p:TestingMode=NonInteractiveVisual \
+              -p:IncludeFailingTests=false \
               -p:AndroidSdkDirectory=$ANDROID_SDK_ROOT \
               /bl:./artifacts/logs/msbuild-publish.binlog
           displayName: 'Publish App'

--- a/.azure/templates/test-tcp-ios.yml
+++ b/.azure/templates/test-tcp-ios.yml
@@ -51,6 +51,7 @@ jobs:
               -r $(TEST_RUNTIME_IDENTIFIER) \
               -c $(TEST_CONFIGURATION) \
               -p:TestingMode=NonInteractiveVisual \
+              -p:IncludeFailingTests=false \
               /bl:./artifacts/logs/msbuild-publish.binlog
           displayName: 'Publish App'
         - script: |

--- a/.azure/templates/test-tcp-macos.yml
+++ b/.azure/templates/test-tcp-macos.yml
@@ -36,6 +36,7 @@ jobs:
               -r $(TEST_RUNTIME_IDENTIFIER) \
               -c $(TEST_CONFIGURATION) \
               -p:TestingMode=NonInteractiveVisual \
+              -p:IncludeFailingTests=false \
               /bl:./artifacts/logs/msbuild-publish.binlog
           displayName: 'Publish App'
         - script: |

--- a/.azure/templates/test-tcp-windows-loose.yml
+++ b/.azure/templates/test-tcp-windows-loose.yml
@@ -37,6 +37,7 @@ jobs:
             -f $(TEST_TARGET_FRAMEWORK) `
             -c $(TEST_CONFIGURATION) `
             -p:TestingMode=NonInteractiveVisual `
+            -p:IncludeFailingTests=false `
             /bl:./artifacts/logs/msbuild-build-loose.binlog
         displayName: 'Build App (loose layout)'
       - pwsh: |

--- a/.azure/templates/test-tcp-windows-unpackaged.yml
+++ b/.azure/templates/test-tcp-windows-unpackaged.yml
@@ -33,6 +33,7 @@ jobs:
             -f $(TEST_TARGET_FRAMEWORK) `
             -c $(TEST_CONFIGURATION) `
             -p:TestingMode=NonInteractiveVisual `
+            -p:IncludeFailingTests=false `
             -p:WindowsPackageType=None `
             --output artifacts/publish `
             /bl:./artifacts/logs/msbuild-publish-unpackaged.binlog

--- a/.azure/templates/test-tcp-windows.yml
+++ b/.azure/templates/test-tcp-windows.yml
@@ -35,6 +35,7 @@ jobs:
             -f $(TEST_TARGET_FRAMEWORK) `
             -c $(TEST_CONFIGURATION) `
             -p:TestingMode=NonInteractiveVisual `
+            -p:IncludeFailingTests=false `
             -p:AppxPackageSigningEnabled=true `
             -p:PackageCertificateThumbprint=$fingerprint `
             -p:PackageCertificateKeyFile="" `

--- a/.azure/templates/test-wasm-browser.yml
+++ b/.azure/templates/test-wasm-browser.yml
@@ -32,6 +32,7 @@ jobs:
           device-runners wasm test \
             --app "$wwwroot" \
             --timeout ${{ parameters.timeout }} \
+            --filter "Category!=ExpectedFailure" \
             --logger "trx;LogFileName=test-results.trx" \
             --results-directory artifacts/test-results
         displayName: 'Run Tests'

--- a/.azure/templates/test-xharness-android.yml
+++ b/.azure/templates/test-xharness-android.yml
@@ -84,6 +84,7 @@ jobs:
               -r $(TEST_RUNTIME_IDENTIFIER) \
               -c $(TEST_CONFIGURATION) \
               -p:TestingMode=XHarness \
+              -p:IncludeFailingTests=false \
               -p:AndroidSdkDirectory=$ANDROID_SDK_ROOT \
               /bl:./artifacts/logs/msbuild-publish.binlog
           displayName: 'Publish App'

--- a/.azure/templates/test-xharness-ios.yml
+++ b/.azure/templates/test-xharness-ios.yml
@@ -43,6 +43,7 @@ jobs:
               -r $(TEST_RUNTIME_IDENTIFIER) \
               -c $(TEST_CONFIGURATION) \
               -p:TestingMode=XHarness \
+              -p:IncludeFailingTests=false \
               /bl:./artifacts/logs/msbuild-publish.binlog
           displayName: 'Publish App'
         - script: |

--- a/.azure/templates/test-xharness-maccatalyst.yml
+++ b/.azure/templates/test-xharness-maccatalyst.yml
@@ -34,6 +34,7 @@ jobs:
               -r $(TEST_RUNTIME_IDENTIFIER) \
               -c $(TEST_CONFIGURATION) \
               -p:TestingMode=XHarness \
+              -p:IncludeFailingTests=false \
               /bl:./artifacts/logs/msbuild-publish.binlog
           displayName: 'Publish App'
         - script: |

--- a/.azure/templates/test-xharness-windows.yml
+++ b/.azure/templates/test-xharness-windows.yml
@@ -30,6 +30,7 @@ jobs:
             -f $(TEST_TARGET_FRAMEWORK) `
             -c $(TEST_CONFIGURATION) `
             -p:TestingMode=XHarness `
+            -p:IncludeFailingTests=false `
             -p:AppxPackageSigningEnabled=true `
             -p:PackageCertificateThumbprint=$fingerprint `
             -p:PackageCertificateKeyFile="" `

--- a/.github/workflows/test-dotnet-test-android-linux/action.yml
+++ b/.github/workflows/test-dotnet-test-android-linux/action.yml
@@ -82,6 +82,7 @@ runs:
           -f ${{ inputs.target-framework }} \
           -c ${{ inputs.configuration }} \
           -p:AndroidSdkDirectory=$ANDROID_SDK_ROOT \
+          --filter "Category!=ExpectedFailure" \
           --logger "trx;LogFileName=test-results.trx" \
           /bl:./artifacts/logs/msbuild-test.binlog
     - name: Capture Logcat

--- a/.github/workflows/test-dotnet-test-ios/action.yml
+++ b/.github/workflows/test-dotnet-test-ios/action.yml
@@ -46,6 +46,7 @@ runs:
           -r ${{ inputs.runtime-identifier }} \
           -c ${{ inputs.configuration }} \
           -p:DeviceRunnersDevice=$SIMULATOR_UDID \
+          --filter "Category!=ExpectedFailure" \
           --logger "trx;LogFileName=test-results.trx" \
           /bl:./artifacts/logs/msbuild-test.binlog
     - name: Clean up build artifacts before upload

--- a/.github/workflows/test-dotnet-test-macos/action.yml
+++ b/.github/workflows/test-dotnet-test-macos/action.yml
@@ -33,6 +33,7 @@ runs:
           -f ${{ inputs.target-framework }} \
           -r ${{ inputs.runtime-identifier }} \
           -c ${{ inputs.configuration }} \
+          --filter "Category!=ExpectedFailure" \
           --logger "trx;LogFileName=test-results.trx" \
           /bl:./artifacts/logs/msbuild-test.binlog
     - name: Clean up build artifacts before upload

--- a/.github/workflows/test-dotnet-test-wasm/action.yml
+++ b/.github/workflows/test-dotnet-test-wasm/action.yml
@@ -25,6 +25,7 @@ runs:
       run: |
         dotnet test ${{ inputs.test-project }} \
           -c ${{ inputs.configuration }} \
+          --filter "Category!=ExpectedFailure" \
           --logger "trx;LogFileName=test-results.trx" \
           /bl:./artifacts/logs/msbuild-test.binlog
     - name: Clean up build artifacts before upload

--- a/.github/workflows/test-dotnet-test-windows-exe/action.yml
+++ b/.github/workflows/test-dotnet-test-windows-exe/action.yml
@@ -30,6 +30,7 @@ runs:
           -f ${{ inputs.target-framework }} `
           -c ${{ inputs.configuration }} `
           -p:WindowsPackageType=None `
+          --filter "Category!=ExpectedFailure" `
           --logger "trx;LogFileName=test-results.trx" `
           /bl:./artifacts/logs/msbuild-test.binlog
     - name: Clean up build artifacts before upload

--- a/.github/workflows/test-dotnet-test-windows/action.yml
+++ b/.github/workflows/test-dotnet-test-windows/action.yml
@@ -50,6 +50,7 @@ runs:
         dotnet test ${{ inputs.test-project }} `
           -f ${{ inputs.target-framework }} `
           -c ${{ inputs.configuration }} `
+          --filter "Category!=ExpectedFailure" `
           --logger "trx;LogFileName=test-results.trx" `
           /bl:./artifacts/logs/msbuild-test.binlog
     - name: Clean up build artifacts before upload

--- a/.github/workflows/test-tcp-android-linux/action.yml
+++ b/.github/workflows/test-tcp-android-linux/action.yml
@@ -102,6 +102,7 @@ runs:
           --app artifacts/bin/DeviceTestingKitApp.DeviceTests/${{ inputs.configuration }}_${{ inputs.target-framework }}_${{ inputs.runtime-identifier }}/com.companyname.devicetestingkitapp.devicetests-Signed.apk \
           --results-directory artifacts/test-results \
           --connection-timeout ${{ inputs.connection-timeout }} \
+          --filter "Category!=ExpectedFailure" \
           --logger trx
     - name: Capture Logcat
       if: always()

--- a/.github/workflows/test-tcp-android-linux/action.yml
+++ b/.github/workflows/test-tcp-android-linux/action.yml
@@ -93,6 +93,7 @@ runs:
           -r ${{ inputs.runtime-identifier }} \
           -c ${{ inputs.configuration }} \
           -p:TestingMode=NonInteractiveVisual \
+          -p:IncludeFailingTests=false \
           -p:AndroidSdkDirectory=$ANDROID_SDK_ROOT \
           /bl:./artifacts/logs/msbuild-publish.binlog
     - name: Run Tests
@@ -102,7 +103,6 @@ runs:
           --app artifacts/bin/DeviceTestingKitApp.DeviceTests/${{ inputs.configuration }}_${{ inputs.target-framework }}_${{ inputs.runtime-identifier }}/com.companyname.devicetestingkitapp.devicetests-Signed.apk \
           --results-directory artifacts/test-results \
           --connection-timeout ${{ inputs.connection-timeout }} \
-          --filter "Category!=ExpectedFailure" \
           --logger trx
     - name: Capture Logcat
       if: always()

--- a/.github/workflows/test-tcp-ios/action.yml
+++ b/.github/workflows/test-tcp-ios/action.yml
@@ -55,13 +55,14 @@ runs:
           -r ${{ inputs.runtime-identifier }} \
           -c ${{ inputs.configuration }} \
           -p:TestingMode=NonInteractiveVisual \
+          -p:IncludeFailingTests=false \
           /bl:./artifacts/logs/msbuild-publish.binlog
     - name: Run Tests
       shell: bash
       run: |
         app_bundle=$(find artifacts/bin -name "*.app" -type d | head -1)
         [ -n "$app_bundle" ] || { echo "::error::No .app bundle found in artifacts/bin"; exit 1; }
-        device-runners ios test --app "$app_bundle" --device "${{ steps.simulator.outputs.udid }}" --results-directory artifacts/test-results --filter "Category!=ExpectedFailure" --logger trx
+        device-runners ios test --app "$app_bundle" --device "${{ steps.simulator.outputs.udid }}" --results-directory artifacts/test-results --logger trx
     - name: Cleanup Simulator
       if: always()
       shell: bash

--- a/.github/workflows/test-tcp-ios/action.yml
+++ b/.github/workflows/test-tcp-ios/action.yml
@@ -61,7 +61,7 @@ runs:
       run: |
         app_bundle=$(find artifacts/bin -name "*.app" -type d | head -1)
         [ -n "$app_bundle" ] || { echo "::error::No .app bundle found in artifacts/bin"; exit 1; }
-        device-runners ios test --app "$app_bundle" --device "${{ steps.simulator.outputs.udid }}" --results-directory artifacts/test-results --logger trx
+        device-runners ios test --app "$app_bundle" --device "${{ steps.simulator.outputs.udid }}" --results-directory artifacts/test-results --filter "Category!=ExpectedFailure" --logger trx
     - name: Cleanup Simulator
       if: always()
       shell: bash

--- a/.github/workflows/test-tcp-macos/action.yml
+++ b/.github/workflows/test-tcp-macos/action.yml
@@ -40,13 +40,14 @@ runs:
           -r ${{ inputs.runtime-identifier }} \
           -c ${{ inputs.configuration }} \
           -p:TestingMode=NonInteractiveVisual \
+          -p:IncludeFailingTests=false \
           /bl:./artifacts/logs/msbuild-publish.binlog
     - name: Run Tests
       shell: bash
       run: |
         app_bundle=$(find artifacts/bin -name "*.app" -type d | head -1)
         [ -n "$app_bundle" ] || { echo "::error::No .app bundle found in artifacts/bin"; exit 1; }
-        device-runners macos test --app "$app_bundle" --results-directory artifacts/test-results --filter "Category!=ExpectedFailure" --logger trx
+        device-runners macos test --app "$app_bundle" --results-directory artifacts/test-results --logger trx
     - name: Clean up build artifacts before upload
       if: always()
       shell: bash

--- a/.github/workflows/test-tcp-macos/action.yml
+++ b/.github/workflows/test-tcp-macos/action.yml
@@ -46,7 +46,7 @@ runs:
       run: |
         app_bundle=$(find artifacts/bin -name "*.app" -type d | head -1)
         [ -n "$app_bundle" ] || { echo "::error::No .app bundle found in artifacts/bin"; exit 1; }
-        device-runners macos test --app "$app_bundle" --results-directory artifacts/test-results --logger trx
+        device-runners macos test --app "$app_bundle" --results-directory artifacts/test-results --filter "Category!=ExpectedFailure" --logger trx
     - name: Clean up build artifacts before upload
       if: always()
       shell: bash

--- a/.github/workflows/test-tcp-windows-loose/action.yml
+++ b/.github/workflows/test-tcp-windows-loose/action.yml
@@ -37,6 +37,7 @@ runs:
           -f ${{ inputs.target-framework }} `
           -c ${{ inputs.configuration }} `
           -p:TestingMode=NonInteractiveVisual `
+          -p:IncludeFailingTests=false `
           /bl:./artifacts/logs/msbuild-build-loose.binlog
     - name: Install Windows App Runtime framework
       shell: pwsh
@@ -57,7 +58,7 @@ runs:
         $buildOutput = "artifacts/bin/DeviceTestingKitApp.DeviceTests"
         $manifest = Get-ChildItem -Path $buildOutput -Filter "AppxManifest.xml" -Recurse | Select-Object -First 1
         if (-not $manifest) { Write-Error "No AppxManifest.xml found in $buildOutput"; exit 1 }
-        device-runners windows test --app $manifest.DirectoryName --results-directory artifacts/test-results --filter "Category!=ExpectedFailure" --logger trx
+        device-runners windows test --app $manifest.DirectoryName --results-directory artifacts/test-results --logger trx
     - name: Clean up build artifacts before upload
       if: always()
       shell: pwsh

--- a/.github/workflows/test-tcp-windows-loose/action.yml
+++ b/.github/workflows/test-tcp-windows-loose/action.yml
@@ -57,7 +57,7 @@ runs:
         $buildOutput = "artifacts/bin/DeviceTestingKitApp.DeviceTests"
         $manifest = Get-ChildItem -Path $buildOutput -Filter "AppxManifest.xml" -Recurse | Select-Object -First 1
         if (-not $manifest) { Write-Error "No AppxManifest.xml found in $buildOutput"; exit 1 }
-        device-runners windows test --app $manifest.DirectoryName --results-directory artifacts/test-results --logger trx
+        device-runners windows test --app $manifest.DirectoryName --results-directory artifacts/test-results --filter "Category!=ExpectedFailure" --logger trx
     - name: Clean up build artifacts before upload
       if: always()
       shell: pwsh

--- a/.github/workflows/test-tcp-windows-unpackaged/action.yml
+++ b/.github/workflows/test-tcp-windows-unpackaged/action.yml
@@ -32,6 +32,7 @@ runs:
           -f ${{ inputs.target-framework }} `
           -c ${{ inputs.configuration }} `
           -p:TestingMode=NonInteractiveVisual `
+          -p:IncludeFailingTests=false `
           -p:WindowsPackageType=None `
           --output artifacts/publish `
           /bl:./artifacts/logs/msbuild-publish-unpackaged.binlog
@@ -39,7 +40,7 @@ runs:
       shell: pwsh
       run: |
         $exe = Get-ChildItem "artifacts/publish/DeviceTestingKitApp.DeviceTests.exe"
-        device-runners windows test --app $exe --results-directory artifacts/test-results --filter "Category!=ExpectedFailure" --logger trx
+        device-runners windows test --app $exe --results-directory artifacts/test-results --logger trx
     - name: Upload Artifacts
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/test-tcp-windows-unpackaged/action.yml
+++ b/.github/workflows/test-tcp-windows-unpackaged/action.yml
@@ -39,7 +39,7 @@ runs:
       shell: pwsh
       run: |
         $exe = Get-ChildItem "artifacts/publish/DeviceTestingKitApp.DeviceTests.exe"
-        device-runners windows test --app $exe --results-directory artifacts/test-results --logger trx
+        device-runners windows test --app $exe --results-directory artifacts/test-results --filter "Category!=ExpectedFailure" --logger trx
     - name: Upload Artifacts
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/test-tcp-windows/action.yml
+++ b/.github/workflows/test-tcp-windows/action.yml
@@ -44,7 +44,7 @@ runs:
       run: |
         $msix = (Get-ChildItem -Recurse -Filter "*.msix" -Path "artifacts" | Select-Object -First 1).FullName
         if (-not $msix) { Write-Error "No .msix file found in artifacts"; exit 1 }
-        device-runners windows test --app $msix --results-directory artifacts/test-results --logger trx
+        device-runners windows test --app $msix --results-directory artifacts/test-results --filter "Category!=ExpectedFailure" --logger trx
     - name: Clean up build artifacts before upload
       if: always()
       shell: pwsh

--- a/.github/workflows/test-tcp-windows/action.yml
+++ b/.github/workflows/test-tcp-windows/action.yml
@@ -34,6 +34,7 @@ runs:
           -f ${{ inputs.target-framework }} `
           -c ${{ inputs.configuration }} `
           -p:TestingMode=NonInteractiveVisual `
+          -p:IncludeFailingTests=false `
           -p:AppxPackageSigningEnabled=true `
           -p:PackageCertificateThumbprint=$fingerprint `
           -p:PackageCertificateKeyFile="" `
@@ -44,7 +45,7 @@ runs:
       run: |
         $msix = (Get-ChildItem -Recurse -Filter "*.msix" -Path "artifacts" | Select-Object -First 1).FullName
         if (-not $msix) { Write-Error "No .msix file found in artifacts"; exit 1 }
-        device-runners windows test --app $msix --results-directory artifacts/test-results --filter "Category!=ExpectedFailure" --logger trx
+        device-runners windows test --app $msix --results-directory artifacts/test-results --logger trx
     - name: Clean up build artifacts before upload
       if: always()
       shell: pwsh

--- a/.github/workflows/test-wasm-browser/action.yml
+++ b/.github/workflows/test-wasm-browser/action.yml
@@ -39,6 +39,7 @@ runs:
         device-runners wasm test \
           --app "$wwwroot" \
           --timeout ${{ inputs.timeout }} \
+          --filter "Category!=ExpectedFailure" \
           --logger "trx;LogFileName=test-results.trx" \
           --results-directory artifacts/test-results
     - name: Clean up build artifacts before upload

--- a/.github/workflows/test-xharness-android-linux/action.yml
+++ b/.github/workflows/test-xharness-android-linux/action.yml
@@ -85,6 +85,7 @@ runs:
           -r ${{ inputs.runtime-identifier }} \
           -c ${{ inputs.configuration }} \
           -p:TestingMode=XHarness \
+          -p:IncludeFailingTests=false \
           -p:AndroidSdkDirectory=$ANDROID_SDK_ROOT \
           /bl:./artifacts/logs/msbuild-publish.binlog
     - name: Set ADB_EXE_PATH for XHarness

--- a/.github/workflows/test-xharness-ios/action.yml
+++ b/.github/workflows/test-xharness-ios/action.yml
@@ -50,6 +50,7 @@ runs:
           -r ${{ inputs.runtime-identifier }} \
           -c ${{ inputs.configuration }} \
           -p:TestingMode=XHarness \
+          -p:IncludeFailingTests=false \
           /bl:./artifacts/logs/msbuild-publish.binlog
     - name: Discover App Bundle
       id: app

--- a/.github/workflows/test-xharness-maccatalyst/action.yml
+++ b/.github/workflows/test-xharness-maccatalyst/action.yml
@@ -35,6 +35,7 @@ runs:
           -r ${{ inputs.runtime-identifier }} \
           -c ${{ inputs.configuration }} \
           -p:TestingMode=XHarness \
+          -p:IncludeFailingTests=false \
           /bl:./artifacts/logs/msbuild-publish.binlog
     - name: Discover App Bundle
       id: app

--- a/.github/workflows/test-xharness-windows/action.yml
+++ b/.github/workflows/test-xharness-windows/action.yml
@@ -28,6 +28,7 @@ runs:
           -f ${{ inputs.target-framework }} `
           -c ${{ inputs.configuration }} `
           -p:TestingMode=XHarness `
+          -p:IncludeFailingTests=false `
           -p:AppxPackageSigningEnabled=true `
           -p:PackageCertificateThumbprint=$fingerprint `
           -p:PackageCertificateKeyFile="" `

--- a/docs/articles/ci-pipeline.md
+++ b/docs/articles/ci-pipeline.md
@@ -162,6 +162,19 @@ The `DeviceRunners.Testing.Targets` package is included in the test project via 
 > [!NOTE]
 > The `dotnet test` workflows (`test-dotnet-test-*`) run tests via `dotnet test` and the `DeviceRunners.Testing.Targets` package. The TCP workflows (`test-tcp-*`) use the DeviceRunners CLI directly for scenarios requiring more control. The XHarness workflows remain as a legacy alternative.
 
+### Excluding the intentionally-failing demo tests
+
+The sample suite ships a handful of **intentionally-failing** demo tests so the various runners can be shown reporting failures. They are tagged with the `ExpectedFailure` category (`[Trait("Category", "ExpectedFailure")]` for xUnit/xUnit v3, `[Category("ExpectedFailure")]` for NUnit). To keep CI green, every device test job excludes that category. The mechanism differs by runner because not all of them accept a runtime filter:
+
+| Workflow | Exclusion mechanism |
+|---|---|
+| `test-dotnet-test-*` | `--filter "Category!=ExpectedFailure"` on the `dotnet test` command line |
+| `test-tcp-*` | Built with `-p:IncludeFailingTests=false`, which compiles the demo tests out via `#if INCLUDE_FAILING_TESTS` (the installed app cannot reliably receive a runtime filter on every platform) |
+| WASM (`device-runners wasm test`) | `--filter "Category!=ExpectedFailure"` on the CLI |
+| XHarness | Skipped in-process via `.SkipCategory("Category", "ExpectedFailure")` |
+
+When adding or editing a device test job, mirror the matching mechanism above in **both** `.github/workflows/test-*/action.yml` and `.azure/templates/test-*.yml` so the two CI services stay in sync.
+
 ## Device Management Patterns
 
 ### Android Emulator (via `dotnet android`)

--- a/docs/articles/ci-pipeline.md
+++ b/docs/articles/ci-pipeline.md
@@ -164,14 +164,17 @@ The `DeviceRunners.Testing.Targets` package is included in the test project via 
 
 ### Excluding the intentionally-failing demo tests
 
-The sample suite ships a handful of **intentionally-failing** demo tests so the various runners can be shown reporting failures. They are tagged with the `ExpectedFailure` category (`[Trait("Category", "ExpectedFailure")]` for xUnit/xUnit v3, `[Category("ExpectedFailure")]` for NUnit). To keep CI green, every device test job excludes that category. The mechanism differs by runner because not all of them accept a runtime filter:
+The sample suite ships a handful of **intentionally-failing** demo tests so the various runners can be shown reporting failures. They are tagged with the `ExpectedFailure` category (`[Trait("Category", "ExpectedFailure")]` for xUnit/xUnit v3, `[Category("ExpectedFailure")]` for NUnit). The failing tests always compile in (so they stay visible for local/interactive runs); to keep CI green, every device test job excludes that category. Most jobs build the app with `-p:IncludeFailingTests=false`, which defines the `EXCLUDE_FAILING_TESTS` compile constant that the sample's `MauiProgram` reads to bake the exclusion into the runner — `dotnet test` is the exception and uses a true command-line filter:
 
 | Workflow | Exclusion mechanism |
 |---|---|
-| `test-dotnet-test-*` | `--filter "Category!=ExpectedFailure"` on the `dotnet test` command line |
-| `test-tcp-*` | Built with `-p:IncludeFailingTests=false`, which defines the `EXCLUDE_FAILING_TESTS` compile constant. The sample's `MauiProgram` reads that constant and bakes `SetTestCaseFilter("Category!=ExpectedFailure")` into the runner (the installed app auto-starts without receiving a runtime filter on every platform). The failing tests still compile in — they are excluded at runtime by the baked filter. |
+| `test-dotnet-test-*` | `--filter "Category!=ExpectedFailure"` on the `dotnet test` command line (delivered to the app as a runtime filter) |
+| `test-tcp-*` | Built with `-p:IncludeFailingTests=false`. `MauiProgram` reads `EXCLUDE_FAILING_TESTS` and bakes `SetTestCaseFilter("Category!=ExpectedFailure")` into the visual runner (the installed app auto-starts without receiving a runtime filter on every platform). |
 | WASM (`device-runners wasm test`) | `--filter "Category!=ExpectedFailure"` on the CLI |
-| XHarness | Skipped in-process via `.SkipCategory("Category", "ExpectedFailure")` |
+| `test-xharness-*` | Built with `-p:IncludeFailingTests=false`. `MauiProgram` reads `EXCLUDE_FAILING_TESTS` and skips the category in-process via `.SkipCategory("Category", "ExpectedFailure")`. |
+
+> [!NOTE]
+> Because the exclusion is gated on `-p:IncludeFailingTests=false`, a local XHarness or TCP run built without that property runs the failing demo tests and reports them as failures — which is the intended behaviour for demonstrating the runners.
 
 When adding or editing a device test job, mirror the matching mechanism above in **both** `.github/workflows/test-*/action.yml` and `.azure/templates/test-*.yml` so the two CI services stay in sync.
 

--- a/docs/articles/ci-pipeline.md
+++ b/docs/articles/ci-pipeline.md
@@ -169,7 +169,7 @@ The sample suite ships a handful of **intentionally-failing** demo tests so the 
 | Workflow | Exclusion mechanism |
 |---|---|
 | `test-dotnet-test-*` | `--filter "Category!=ExpectedFailure"` on the `dotnet test` command line |
-| `test-tcp-*` | Built with `-p:IncludeFailingTests=false`, which compiles the demo tests out via `#if INCLUDE_FAILING_TESTS` (the installed app cannot reliably receive a runtime filter on every platform) |
+| `test-tcp-*` | Built with `-p:IncludeFailingTests=false`, which defines the `EXCLUDE_FAILING_TESTS` compile constant. The sample's `MauiProgram` reads that constant and bakes `SetTestCaseFilter("Category!=ExpectedFailure")` into the runner (the installed app auto-starts without receiving a runtime filter on every platform). The failing tests still compile in — they are excluded at runtime by the baked filter. |
 | WASM (`device-runners wasm test`) | `--filter "Category!=ExpectedFailure"` on the CLI |
 | XHarness | Skipped in-process via `.SkipCategory("Category", "ExpectedFailure")` |
 

--- a/docs/articles/using-dotnet-test.md
+++ b/docs/articles/using-dotnet-test.md
@@ -106,6 +106,19 @@ tests results in an empty run.
 > The filter only affects the headless `dotnet test`/CLI run. Launching the app interactively
 > from the IDE always shows the full visual runner.
 
+#### Excluding known-failing tests
+
+The sample test suite tags intentionally-failing demo tests with the `ExpectedFailure`
+category (`[Trait("Category", "ExpectedFailure")]` for xUnit/xUnit v3,
+`[Category("ExpectedFailure")]` for NUnit). CI keeps the suite green by excluding that
+category instead of compiling the tests out:
+
+- **`dotnet test`** – the sample app projects default `$(VSTestTestCaseFilter)` to
+  `Category!=ExpectedFailure` when `CI`/`TF_BUILD` is set. An explicit `--filter` overrides it.
+- **CLI runs (TCP/WASM)** – the workflows pass `--filter "Category!=ExpectedFailure"`.
+- **XHarness** – the app skips the category in-process via
+  `.SkipCategory("Category", "ExpectedFailure")`.
+
 ## Output
 
 The output matches the standard `dotnet test` format:

--- a/docs/articles/using-dotnet-test.md
+++ b/docs/articles/using-dotnet-test.md
@@ -61,6 +61,51 @@ dotnet test MyApp.DeviceTests.csproj -f net10.0-maccatalyst
 
 That's it. The package handles building the app, deploying it, launching it with the right environment variables, collecting results, and producing a TRX file.
 
+### Filtering Tests
+
+You can run a single test or a subset of tests using the standard `dotnet test --filter` option. The filter expression is forwarded to the device app, which runs only the matching tests instead of the whole suite.
+
+```bash
+# Run a single test by its fully qualified name
+dotnet test MyApp.DeviceTests.csproj -f net10.0-maccatalyst \
+  --filter "FullyQualifiedName=MyApp.Tests.CalculatorTests.Adds"
+
+# Run every test in a single class
+dotnet test MyApp.DeviceTests.csproj -f net10.0-maccatalyst \
+  --filter "FullyQualifiedName~CalculatorTests"
+
+# Run tests in a trait/category
+dotnet test MyApp.DeviceTests.csproj -f net10.0-maccatalyst \
+  --filter "Category=Smoke"
+```
+
+The on-device evaluator mirrors the documented `dotnet test --filter` syntax:
+
+| Property | Description |
+|----------|-------------|
+| `FullyQualifiedName` | `Namespace.Class.Method` (the **default** when no property is given) |
+| `DisplayName` | The test's display name |
+| `Name` | The test method's simple name |
+| `ClassName` | The fully qualified test class name |
+| `Namespace` | The test class namespace |
+| _any trait name_ | A trait/category value (e.g. `Category`, `Priority`) |
+
+| Operator | Meaning |
+|----------|---------|
+| `=` | Equals (case-insensitive) |
+| `!=` | Not equals |
+| `~` | Contains |
+| `!~` | Does not contain |
+
+Conditions can be combined with `&` (and), `|` (or) and grouped with parentheses. `&`
+binds tighter than `|`. Use `\` to escape a special character. Filtering works across all
+supported frameworks (xUnit v2, xUnit v3 and NUnit) and platforms. A filter that matches no
+tests results in an empty run.
+
+> [!NOTE]
+> The filter only affects the headless `dotnet test`/CLI run. Launching the app interactively
+> from the IDE always shows the full visual runner.
+
 ## Output
 
 The output matches the standard `dotnet test` format:

--- a/docs/articles/using-dotnet-test.md
+++ b/docs/articles/using-dotnet-test.md
@@ -113,8 +113,7 @@ category (`[Trait("Category", "ExpectedFailure")]` for xUnit/xUnit v3,
 `[Category("ExpectedFailure")]` for NUnit). CI keeps the suite green by excluding that
 category instead of compiling the tests out:
 
-- **`dotnet test`** – the sample app projects default `$(VSTestTestCaseFilter)` to
-  `Category!=ExpectedFailure` when `CI`/`TF_BUILD` is set. An explicit `--filter` overrides it.
+- **`dotnet test`** – CI passes `--filter "Category!=ExpectedFailure"` on the command line.
 - **CLI runs (TCP/WASM)** – the workflows pass `--filter "Category!=ExpectedFailure"`.
 - **XHarness** – the app skips the category in-process via
   `.SkipCategory("Category", "ExpectedFailure")`.

--- a/docs/articles/using-dotnet-test.md
+++ b/docs/articles/using-dotnet-test.md
@@ -110,11 +110,13 @@ tests results in an empty run.
 
 The sample test suite tags intentionally-failing demo tests with the `ExpectedFailure`
 category (`[Trait("Category", "ExpectedFailure")]` for xUnit/xUnit v3,
-`[Category("ExpectedFailure")]` for NUnit). CI keeps the suite green by excluding that
-category instead of compiling the tests out:
+`[Category("ExpectedFailure")]` for NUnit). CI keeps the suite green by excluding them:
 
 - **`dotnet test`** – CI passes `--filter "Category!=ExpectedFailure"` on the command line.
-- **CLI runs (TCP/WASM)** – the workflows pass `--filter "Category!=ExpectedFailure"`.
+- **CLI TCP runs** – these launch an installed app that cannot receive a runtime filter
+  on every platform, so the workflows build with `-p:IncludeFailingTests=false`, which
+  compiles the failing demo tests out (they are wrapped in `#if INCLUDE_FAILING_TESTS`).
+- **CLI WASM runs** – the workflow passes `--filter "Category!=ExpectedFailure"`.
 - **XHarness** – the app skips the category in-process via
   `.SkipCategory("Category", "ExpectedFailure")`.
 

--- a/docs/articles/using-dotnet-test.md
+++ b/docs/articles/using-dotnet-test.md
@@ -110,20 +110,6 @@ code) rather than silently running everything.
 > The filter only affects the headless `dotnet test`/CLI run. Launching the app interactively
 > from the IDE always shows the full visual runner.
 
-#### Excluding known-failing tests
-
-The sample test suite tags intentionally-failing demo tests with the `ExpectedFailure`
-category (`[Trait("Category", "ExpectedFailure")]` for xUnit/xUnit v3,
-`[Category("ExpectedFailure")]` for NUnit). CI keeps the suite green by excluding them:
-
-- **`dotnet test`** – CI passes `--filter "Category!=ExpectedFailure"` on the command line.
-- **CLI TCP runs** – these launch an installed app that cannot receive a runtime filter
-  on every platform, so the workflows build with `-p:IncludeFailingTests=false`, which
-  compiles the failing demo tests out (they are wrapped in `#if INCLUDE_FAILING_TESTS`).
-- **CLI WASM runs** – the workflow passes `--filter "Category!=ExpectedFailure"`.
-- **XHarness** – the app skips the category in-process via
-  `.SkipCategory("Category", "ExpectedFailure")`.
-
 ## Output
 
 The output matches the standard `dotnet test` format:

--- a/docs/articles/using-dotnet-test.md
+++ b/docs/articles/using-dotnet-test.md
@@ -99,8 +99,12 @@ The on-device evaluator mirrors the documented `dotnet test --filter` syntax:
 
 Conditions can be combined with `&` (and), `|` (or) and grouped with parentheses. `&`
 binds tighter than `|`. Use `\` to escape a special character. Filtering works across all
-supported frameworks (xUnit v2, xUnit v3 and NUnit) and platforms. A filter that matches no
-tests results in an empty run.
+supported frameworks (xUnit v2, xUnit v3 and NUnit) and platforms.
+
+A filter that matches no tests is a **successful empty run** (exit code `0`), mirroring
+`dotnet test --filter`, which prints "No test matches the given testcase filter". An
+**invalid** filter expression aborts the run and is reported as a failure (non-zero exit
+code) rather than silently running everything.
 
 > [!NOTE]
 > The filter only affects the headless `dotnet test`/CLI run. Launching the app interactively

--- a/docs/articles/xunit-v3-support.md
+++ b/docs/articles/xunit-v3-support.md
@@ -252,7 +252,7 @@ These limitations apply only to the in-app visual runner, not to `dotnet test` o
 | Feature | Standard `dotnet test` | DeviceRunners Visual Runner |
 |---|---|---|
 | **`[Fact(Explicit = true)]`** | ✅ Runs with `--filter` or explicit opt-in | ⚠️ Executor supports it, but the visual runner UI has no way to opt-in to running explicit tests |
-| **`dotnet test --filter` expressions** | ✅ Full filter syntax | ❌ Visual runner has its own UI-based filtering |
+| **`dotnet test --filter` expressions** | ✅ Full filter syntax | ✅ Headless runs honor `--filter` (a documented subset); the interactive UI also has its own filtering |
 | **Source information** | ✅ IDE navigation to test source | ❌ Not available on in-memory platforms |
 
 ### Behavioral Defaults

--- a/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/DeviceTestingKitApp.BlazorLibrary.NUnitTests.csproj
+++ b/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/DeviceTestingKitApp.BlazorLibrary.NUnitTests.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <DefineConstants Condition="'$(CI)' != 'true' And '$(TF_BUILD)' != 'True'">INCLUDE_FAILING_TESTS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" />

--- a/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.BlazorLibrary.NUnitTests/UnitTests.cs
@@ -15,11 +15,10 @@ public class UnitTests
 	{
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Test]
+	[Category("ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 }

--- a/sample/test/DeviceTestingKitApp.BlazorLibrary.Xunit3Tests/DeviceTestingKitApp.BlazorLibrary.Xunit3Tests.csproj
+++ b/sample/test/DeviceTestingKitApp.BlazorLibrary.Xunit3Tests/DeviceTestingKitApp.BlazorLibrary.Xunit3Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <DefineConstants Condition="'$(CI)' != 'true' And '$(TF_BUILD)' != 'True'">INCLUDE_FAILING_TESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/test/DeviceTestingKitApp.BlazorLibrary.Xunit3Tests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.BlazorLibrary.Xunit3Tests/UnitTests.cs
@@ -15,13 +15,12 @@ public class UnitTests
 	{
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
+	[Trait("Category", "ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 
 	[Theory]
 	[InlineData(1)]

--- a/sample/test/DeviceTestingKitApp.BlazorLibrary.XunitTests/DeviceTestingKitApp.BlazorLibrary.XunitTests.csproj
+++ b/sample/test/DeviceTestingKitApp.BlazorLibrary.XunitTests/DeviceTestingKitApp.BlazorLibrary.XunitTests.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <DefineConstants Condition="'$(CI)' != 'true' And '$(TF_BUILD)' != 'True'">INCLUDE_FAILING_TESTS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" />

--- a/sample/test/DeviceTestingKitApp.BlazorLibrary.XunitTests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.BlazorLibrary.XunitTests/UnitTests.cs
@@ -13,11 +13,10 @@ public class UnitTests
 	{
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
+	[Trait("Category", "ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 }

--- a/sample/test/DeviceTestingKitApp.BrowserTests/DeviceTestingKitApp.BrowserTests.csproj
+++ b/sample/test/DeviceTestingKitApp.BrowserTests/DeviceTestingKitApp.BrowserTests.csproj
@@ -10,7 +10,9 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <DefineConstants Condition="'$(CI)' != 'true' And '$(TF_BUILD)' != 'True'">INCLUDE_FAILING_TESTS</DefineConstants>
+    <!-- In CI, exclude the intentionally-failing demo tests so the suite stays green.
+         An explicit filter passed to "dotnet test" still wins because it overrides the VSTestTestCaseFilter property. -->
+    <VSTestTestCaseFilter Condition="('$(CI)' == 'true' Or '$(TF_BUILD)' == 'True') And '$(VSTestTestCaseFilter)' == ''">Category!=ExpectedFailure</VSTestTestCaseFilter>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/test/DeviceTestingKitApp.BrowserTests/DeviceTestingKitApp.BrowserTests.csproj
+++ b/sample/test/DeviceTestingKitApp.BrowserTests/DeviceTestingKitApp.BrowserTests.csproj
@@ -10,9 +10,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <!-- In CI, exclude the intentionally-failing demo tests so the suite stays green.
-         An explicit filter passed to "dotnet test" still wins because it overrides the VSTestTestCaseFilter property. -->
-    <VSTestTestCaseFilter Condition="('$(CI)' == 'true' Or '$(TF_BUILD)' == 'True') And '$(VSTestTestCaseFilter)' == ''">Category!=ExpectedFailure</VSTestTestCaseFilter>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/test/DeviceTestingKitApp.BrowserTests/Tests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.BrowserTests/Tests/UnitTests.cs
@@ -13,13 +13,12 @@ public class UnitTests
 	{
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
+	[Trait("Category", "ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 
 	[Theory]
 	[InlineData(1)]
@@ -37,12 +36,11 @@ public class UnitTests
 		Assert.True(true);
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
+	[Trait("Category", "ExpectedFailure")]
 	public async Task LongRunningFail()
 	{
 		await Task.Delay(2000);
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 }

--- a/sample/test/DeviceTestingKitApp.BrowserTests/Tests/UnitTestsWithOutput.cs
+++ b/sample/test/DeviceTestingKitApp.BrowserTests/Tests/UnitTestsWithOutput.cs
@@ -17,12 +17,11 @@ public class UnitTestsWithOutput
 		_output.WriteLine("This is test output.");
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
+	[Trait("Category", "ExpectedFailure")]
 	public void FailingOutputTest()
 	{
 		_output.WriteLine("This is test output.");
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 }

--- a/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
@@ -15,9 +15,6 @@
     <RootNamespace>DeviceTestingKitApp.DeviceTests</RootNamespace>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
-    <!-- In CI, exclude the intentionally-failing demo tests so the suite stays green.
-         An explicit filter passed to "dotnet test" still wins because it overrides the VSTestTestCaseFilter property. -->
-    <VSTestTestCaseFilter Condition="('$(CI)' == 'true' Or '$(TF_BUILD)' == 'True') And '$(VSTestTestCaseFilter)' == ''">Category!=ExpectedFailure</VSTestTestCaseFilter>
     <DefineConstants Condition="'$(TestingMode)' == 'NonInteractiveVisual'">$(DefineConstants);MODE_NON_INTERACTIVE_VISUAL</DefineConstants>
     <DefineConstants Condition="'$(TestingMode)' == 'XHarness'">$(DefineConstants);MODE_XHARNESS</DefineConstants>
 

--- a/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
@@ -15,11 +15,12 @@
     <RootNamespace>DeviceTestingKitApp.DeviceTests</RootNamespace>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
-    <!-- Intentionally-failing demo tests are compiled in by default (and excluded by
-         "dotnet test" via "Category!=ExpectedFailure"). TCP device runs that cannot pass
-         a runtime filter set -p:IncludeFailingTests=false to compile them out instead. -->
+    <!-- Intentionally-failing demo tests are always compiled in. "dotnet test" excludes
+         them via "Category!=ExpectedFailure". TCP device runs (which auto-start the runner
+         without a runtime filter) set -p:IncludeFailingTests=false, which defines
+         EXCLUDE_FAILING_TESTS so MauiProgram bakes the same exclusion filter into the app. -->
     <IncludeFailingTests Condition="'$(IncludeFailingTests)' == ''">true</IncludeFailingTests>
-    <DefineConstants Condition="'$(IncludeFailingTests)' == 'true'">$(DefineConstants);INCLUDE_FAILING_TESTS</DefineConstants>
+    <DefineConstants Condition="'$(IncludeFailingTests)' == 'false'">$(DefineConstants);EXCLUDE_FAILING_TESTS</DefineConstants>
     <DefineConstants Condition="'$(TestingMode)' == 'NonInteractiveVisual'">$(DefineConstants);MODE_NON_INTERACTIVE_VISUAL</DefineConstants>
     <DefineConstants Condition="'$(TestingMode)' == 'XHarness'">$(DefineConstants);MODE_XHARNESS</DefineConstants>
 

--- a/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
@@ -15,7 +15,9 @@
     <RootNamespace>DeviceTestingKitApp.DeviceTests</RootNamespace>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
-    <DefineConstants Condition="'$(CI)' != 'true' And '$(TF_BUILD)' != 'True'">$(DefineConstants);INCLUDE_FAILING_TESTS</DefineConstants>
+    <!-- In CI, exclude the intentionally-failing demo tests so the suite stays green.
+         An explicit filter passed to "dotnet test" still wins because it overrides the VSTestTestCaseFilter property. -->
+    <VSTestTestCaseFilter Condition="('$(CI)' == 'true' Or '$(TF_BUILD)' == 'True') And '$(VSTestTestCaseFilter)' == ''">Category!=ExpectedFailure</VSTestTestCaseFilter>
     <DefineConstants Condition="'$(TestingMode)' == 'NonInteractiveVisual'">$(DefineConstants);MODE_NON_INTERACTIVE_VISUAL</DefineConstants>
     <DefineConstants Condition="'$(TestingMode)' == 'XHarness'">$(DefineConstants);MODE_XHARNESS</DefineConstants>
 

--- a/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj
@@ -15,6 +15,11 @@
     <RootNamespace>DeviceTestingKitApp.DeviceTests</RootNamespace>
     <UseMaui>true</UseMaui>
     <SingleProject>true</SingleProject>
+    <!-- Intentionally-failing demo tests are compiled in by default (and excluded by
+         "dotnet test" via "Category!=ExpectedFailure"). TCP device runs that cannot pass
+         a runtime filter set -p:IncludeFailingTests=false to compile them out instead. -->
+    <IncludeFailingTests Condition="'$(IncludeFailingTests)' == ''">true</IncludeFailingTests>
+    <DefineConstants Condition="'$(IncludeFailingTests)' == 'true'">$(DefineConstants);INCLUDE_FAILING_TESTS</DefineConstants>
     <DefineConstants Condition="'$(TestingMode)' == 'NonInteractiveVisual'">$(DefineConstants);MODE_NON_INTERACTIVE_VISUAL</DefineConstants>
     <DefineConstants Condition="'$(TestingMode)' == 'XHarness'">$(DefineConstants);MODE_XHARNESS</DefineConstants>
 

--- a/sample/test/DeviceTestingKitApp.DeviceTests/MauiProgram.cs
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/MauiProgram.cs
@@ -28,15 +28,18 @@ public static class MauiProgram
 			.UseXHarnessTestRunner(conf => conf
 				.AddTestAssembly(typeof(MauiProgram).Assembly)
 				.AddTestAssemblies(typeof(DeviceTestingKitApp.MauiLibrary.XunitTests.UnitTests).Assembly)
+#if EXCLUDE_FAILING_TESTS
 				.SkipCategory("Category", "ExpectedFailure")
+#endif
 				.AddXunit())
 #endif
 			.UseVisualTestRunner(conf => conf
 				.AddCliConfiguration()
 #if EXCLUDE_FAILING_TESTS
-				// TCP device runs auto-start without a runtime filter, so bake in the same
-				// exclusion "dotnet test" uses. Enabled only when built with
-				// -p:IncludeFailingTests=false (the specific TCP CI runs).
+				// Exclude the intentionally-failing demo tests on CI device runs, which
+				// auto-start without a runtime filter. Enabled only when built with
+				// -p:IncludeFailingTests=false (the TCP and XHarness CI runs); local and
+				// interactive runs leave it undefined so the failure demos stay visible.
 				.SetTestCaseFilter("Category!=ExpectedFailure")
 #endif
 #if MODE_NON_INTERACTIVE_VISUAL

--- a/sample/test/DeviceTestingKitApp.DeviceTests/MauiProgram.cs
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/MauiProgram.cs
@@ -28,6 +28,7 @@ public static class MauiProgram
 			.UseXHarnessTestRunner(conf => conf
 				.AddTestAssembly(typeof(MauiProgram).Assembly)
 				.AddTestAssemblies(typeof(DeviceTestingKitApp.MauiLibrary.XunitTests.UnitTests).Assembly)
+				.SkipCategory("Category", "ExpectedFailure")
 				.AddXunit())
 #endif
 			.UseVisualTestRunner(conf => conf

--- a/sample/test/DeviceTestingKitApp.DeviceTests/MauiProgram.cs
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/MauiProgram.cs
@@ -33,6 +33,12 @@ public static class MauiProgram
 #endif
 			.UseVisualTestRunner(conf => conf
 				.AddCliConfiguration()
+#if EXCLUDE_FAILING_TESTS
+				// TCP device runs auto-start without a runtime filter, so bake in the same
+				// exclusion "dotnet test" uses. Enabled only when built with
+				// -p:IncludeFailingTests=false (the specific TCP CI runs).
+				.SetTestCaseFilter("Category!=ExpectedFailure")
+#endif
 #if MODE_NON_INTERACTIVE_VISUAL
 				.EnableAutoStart(true)
 				.AddTcpResultChannel(new TcpResultChannelOptions

--- a/sample/test/DeviceTestingKitApp.DeviceTests/Tests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/Tests/UnitTests.cs
@@ -13,12 +13,14 @@ public class UnitTests
 	{
 	}
 
+#if INCLUDE_FAILING_TESTS
 	[Fact]
 	[Trait("Category", "ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
+#endif
 
 	[Theory]
 	[InlineData(1)]
@@ -36,6 +38,7 @@ public class UnitTests
 		Assert.True(true);
 	}
 
+#if INCLUDE_FAILING_TESTS
 	[Fact]
 	[Trait("Category", "ExpectedFailure")]
 	public async Task LongRunningFail()
@@ -43,4 +46,5 @@ public class UnitTests
 		await Task.Delay(2000);
 		throw new Exception("This is meant to fail.");
 	}
+#endif
 }

--- a/sample/test/DeviceTestingKitApp.DeviceTests/Tests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/Tests/UnitTests.cs
@@ -13,14 +13,12 @@ public class UnitTests
 	{
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
 	[Trait("Category", "ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 
 	[Theory]
 	[InlineData(1)]
@@ -38,7 +36,6 @@ public class UnitTests
 		Assert.True(true);
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
 	[Trait("Category", "ExpectedFailure")]
 	public async Task LongRunningFail()
@@ -46,5 +43,4 @@ public class UnitTests
 		await Task.Delay(2000);
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 }

--- a/sample/test/DeviceTestingKitApp.DeviceTests/Tests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/Tests/UnitTests.cs
@@ -13,13 +13,12 @@ public class UnitTests
 	{
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
+	[Trait("Category", "ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 
 	[Theory]
 	[InlineData(1)]
@@ -37,12 +36,11 @@ public class UnitTests
 		Assert.True(true);
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
+	[Trait("Category", "ExpectedFailure")]
 	public async Task LongRunningFail()
 	{
 		await Task.Delay(2000);
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 }

--- a/sample/test/DeviceTestingKitApp.DeviceTests/Tests/UnitTestsWithOutput.cs
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/Tests/UnitTestsWithOutput.cs
@@ -17,6 +17,7 @@ public class UnitTestsWithOutput
 		_output.WriteLine("This is test output.");
 	}
 
+#if INCLUDE_FAILING_TESTS
 	[Fact]
 	[Trait("Category", "ExpectedFailure")]
 	public void FailingOutputTest()
@@ -24,4 +25,5 @@ public class UnitTestsWithOutput
 		_output.WriteLine("This is test output.");
 		throw new Exception("This is meant to fail.");
 	}
+#endif
 }

--- a/sample/test/DeviceTestingKitApp.DeviceTests/Tests/UnitTestsWithOutput.cs
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/Tests/UnitTestsWithOutput.cs
@@ -17,7 +17,6 @@ public class UnitTestsWithOutput
 		_output.WriteLine("This is test output.");
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
 	[Trait("Category", "ExpectedFailure")]
 	public void FailingOutputTest()
@@ -25,5 +24,4 @@ public class UnitTestsWithOutput
 		_output.WriteLine("This is test output.");
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 }

--- a/sample/test/DeviceTestingKitApp.DeviceTests/Tests/UnitTestsWithOutput.cs
+++ b/sample/test/DeviceTestingKitApp.DeviceTests/Tests/UnitTestsWithOutput.cs
@@ -17,12 +17,11 @@ public class UnitTestsWithOutput
 		_output.WriteLine("This is test output.");
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
+	[Trait("Category", "ExpectedFailure")]
 	public void FailingOutputTest()
 	{
 		_output.WriteLine("This is test output.");
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 }

--- a/sample/test/DeviceTestingKitApp.Library.NUnitTests/DeviceTestingKitApp.Library.NUnitTests.csproj
+++ b/sample/test/DeviceTestingKitApp.Library.NUnitTests/DeviceTestingKitApp.Library.NUnitTests.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Failing demo tests compile in by default; "dotnet test" excludes them via the
+         ExpectedFailure category. TCP device runs set -p:IncludeFailingTests=false. -->
+    <IncludeFailingTests Condition="'$(IncludeFailingTests)' == ''">true</IncludeFailingTests>
+    <DefineConstants Condition="'$(IncludeFailingTests)' == 'true'">$(DefineConstants);INCLUDE_FAILING_TESTS</DefineConstants>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/sample/test/DeviceTestingKitApp.Library.NUnitTests/DeviceTestingKitApp.Library.NUnitTests.csproj
+++ b/sample/test/DeviceTestingKitApp.Library.NUnitTests/DeviceTestingKitApp.Library.NUnitTests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <DefineConstants Condition="'$(CI)' != 'true' And '$(TF_BUILD)' != 'True'">INCLUDE_FAILING_TESTS</DefineConstants>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/sample/test/DeviceTestingKitApp.Library.NUnitTests/DeviceTestingKitApp.Library.NUnitTests.csproj
+++ b/sample/test/DeviceTestingKitApp.Library.NUnitTests/DeviceTestingKitApp.Library.NUnitTests.csproj
@@ -4,10 +4,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Failing demo tests compile in by default; "dotnet test" excludes them via the
-         ExpectedFailure category. TCP device runs set -p:IncludeFailingTests=false. -->
-    <IncludeFailingTests Condition="'$(IncludeFailingTests)' == ''">true</IncludeFailingTests>
-    <DefineConstants Condition="'$(IncludeFailingTests)' == 'true'">$(DefineConstants);INCLUDE_FAILING_TESTS</DefineConstants>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 

--- a/sample/test/DeviceTestingKitApp.Library.NUnitTests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.Library.NUnitTests/UnitTests.cs
@@ -15,10 +15,12 @@ public class UnitTests
 	{
 	}
 
+#if INCLUDE_FAILING_TESTS
 	[Test]
 	[Category("ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
+#endif
 }

--- a/sample/test/DeviceTestingKitApp.Library.NUnitTests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.Library.NUnitTests/UnitTests.cs
@@ -15,11 +15,10 @@ public class UnitTests
 	{
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Test]
+	[Category("ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 }

--- a/sample/test/DeviceTestingKitApp.Library.NUnitTests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.Library.NUnitTests/UnitTests.cs
@@ -15,12 +15,10 @@ public class UnitTests
 	{
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Test]
 	[Category("ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 }

--- a/sample/test/DeviceTestingKitApp.MauiLibrary.Xunit3Tests/DeviceTestingKitApp.MauiLibrary.Xunit3Tests.csproj
+++ b/sample/test/DeviceTestingKitApp.MauiLibrary.Xunit3Tests/DeviceTestingKitApp.MauiLibrary.Xunit3Tests.csproj
@@ -8,7 +8,6 @@
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <DefineConstants Condition="'$(CI)' != 'true' And '$(TF_BUILD)' != 'True'">INCLUDE_FAILING_TESTS</DefineConstants>
     <OutputType Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">Exe</OutputType>
     <TestingPlatformDotnetTestSupport Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">true</TestingPlatformDotnetTestSupport>
 

--- a/sample/test/DeviceTestingKitApp.MauiLibrary.Xunit3Tests/DeviceTestingKitApp.MauiLibrary.Xunit3Tests.csproj
+++ b/sample/test/DeviceTestingKitApp.MauiLibrary.Xunit3Tests/DeviceTestingKitApp.MauiLibrary.Xunit3Tests.csproj
@@ -8,6 +8,10 @@
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Failing demo tests compile in by default; "dotnet test" excludes them via the
+         ExpectedFailure category. TCP device runs set -p:IncludeFailingTests=false. -->
+    <IncludeFailingTests Condition="'$(IncludeFailingTests)' == ''">true</IncludeFailingTests>
+    <DefineConstants Condition="'$(IncludeFailingTests)' == 'true'">$(DefineConstants);INCLUDE_FAILING_TESTS</DefineConstants>
     <OutputType Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">Exe</OutputType>
     <TestingPlatformDotnetTestSupport Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">true</TestingPlatformDotnetTestSupport>
 

--- a/sample/test/DeviceTestingKitApp.MauiLibrary.Xunit3Tests/DeviceTestingKitApp.MauiLibrary.Xunit3Tests.csproj
+++ b/sample/test/DeviceTestingKitApp.MauiLibrary.Xunit3Tests/DeviceTestingKitApp.MauiLibrary.Xunit3Tests.csproj
@@ -8,10 +8,6 @@
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Failing demo tests compile in by default; "dotnet test" excludes them via the
-         ExpectedFailure category. TCP device runs set -p:IncludeFailingTests=false. -->
-    <IncludeFailingTests Condition="'$(IncludeFailingTests)' == ''">true</IncludeFailingTests>
-    <DefineConstants Condition="'$(IncludeFailingTests)' == 'true'">$(DefineConstants);INCLUDE_FAILING_TESTS</DefineConstants>
     <OutputType Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">Exe</OutputType>
     <TestingPlatformDotnetTestSupport Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">true</TestingPlatformDotnetTestSupport>
 

--- a/sample/test/DeviceTestingKitApp.MauiLibrary.Xunit3Tests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.MauiLibrary.Xunit3Tests/UnitTests.cs
@@ -13,13 +13,12 @@ public class UnitTests
 	{
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
+	[Trait("Category", "ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 
 	[Theory]
 	[InlineData(1)]

--- a/sample/test/DeviceTestingKitApp.MauiLibrary.Xunit3Tests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.MauiLibrary.Xunit3Tests/UnitTests.cs
@@ -13,12 +13,14 @@ public class UnitTests
 	{
 	}
 
+#if INCLUDE_FAILING_TESTS
 	[Fact]
 	[Trait("Category", "ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
+#endif
 
 	[Theory]
 	[InlineData(1)]

--- a/sample/test/DeviceTestingKitApp.MauiLibrary.Xunit3Tests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.MauiLibrary.Xunit3Tests/UnitTests.cs
@@ -13,14 +13,12 @@ public class UnitTests
 	{
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
 	[Trait("Category", "ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 
 	[Theory]
 	[InlineData(1)]

--- a/sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/DeviceTestingKitApp.MauiLibrary.XunitTests.csproj
+++ b/sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/DeviceTestingKitApp.MauiLibrary.XunitTests.csproj
@@ -8,6 +8,10 @@
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!-- Failing demo tests compile in by default; "dotnet test" excludes them via the
+         ExpectedFailure category. TCP device runs set -p:IncludeFailingTests=false. -->
+    <IncludeFailingTests Condition="'$(IncludeFailingTests)' == ''">true</IncludeFailingTests>
+    <DefineConstants Condition="'$(IncludeFailingTests)' == 'true'">$(DefineConstants);INCLUDE_FAILING_TESTS</DefineConstants>
     <IsXunitTestProject Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">true</IsXunitTestProject>
     <IsTestProject Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">true</IsTestProject>
 

--- a/sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/DeviceTestingKitApp.MauiLibrary.XunitTests.csproj
+++ b/sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/DeviceTestingKitApp.MauiLibrary.XunitTests.csproj
@@ -8,10 +8,6 @@
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!-- Failing demo tests compile in by default; "dotnet test" excludes them via the
-         ExpectedFailure category. TCP device runs set -p:IncludeFailingTests=false. -->
-    <IncludeFailingTests Condition="'$(IncludeFailingTests)' == ''">true</IncludeFailingTests>
-    <DefineConstants Condition="'$(IncludeFailingTests)' == 'true'">$(DefineConstants);INCLUDE_FAILING_TESTS</DefineConstants>
     <IsXunitTestProject Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">true</IsXunitTestProject>
     <IsTestProject Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">true</IsTestProject>
 

--- a/sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/DeviceTestingKitApp.MauiLibrary.XunitTests.csproj
+++ b/sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/DeviceTestingKitApp.MauiLibrary.XunitTests.csproj
@@ -8,7 +8,6 @@
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <DefineConstants Condition="'$(CI)' != 'true' And '$(TF_BUILD)' != 'True'">INCLUDE_FAILING_TESTS</DefineConstants>
     <IsXunitTestProject Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">true</IsXunitTestProject>
     <IsTestProject Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == ''">true</IsTestProject>
 

--- a/sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/UnitTests.cs
@@ -13,13 +13,12 @@ public class UnitTests
 	{
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
+	[Trait("Category", "ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 
 	[Theory]
 	[InlineData(1)]

--- a/sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/UnitTests.cs
@@ -13,12 +13,14 @@ public class UnitTests
 	{
 	}
 
+#if INCLUDE_FAILING_TESTS
 	[Fact]
 	[Trait("Category", "ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
+#endif
 
 	[Theory]
 	[InlineData(1)]

--- a/sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/UnitTests.cs
+++ b/sample/test/DeviceTestingKitApp.MauiLibrary.XunitTests/UnitTests.cs
@@ -13,14 +13,12 @@ public class UnitTests
 	{
 	}
 
-#if INCLUDE_FAILING_TESTS
 	[Fact]
 	[Trait("Category", "ExpectedFailure")]
 	public void FailingTest()
 	{
 		throw new Exception("This is meant to fail.");
 	}
-#endif
 
 	[Theory]
 	[InlineData(1)]

--- a/src/DeviceRunners.Cli/Commands/BaseTestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/BaseTestCommand.cs
@@ -274,6 +274,32 @@ public abstract class BaseTestCommand<TSettings>(IAnsiConsole console) : BaseCom
 	}
 
 	/// <summary>
+	/// Whether the given outcome represents a successful run: a normal completion
+	/// with no failures, or a clean zero-match run. A crash or a missing run is
+	/// never a success, even if no individual failures were recorded.
+	/// </summary>
+	internal static bool OutcomeIsSuccess(TestRunOutcome outcome, int failedCount) =>
+		outcome switch
+		{
+			TestRunOutcome.Completed => failedCount == 0,
+			TestRunOutcome.CleanEmpty => true,
+			_ => false,
+		};
+
+	/// <summary>
+	/// Maps an outcome to a process exit code, matching the TCP listener semantics:
+	/// 0 = success or clean empty run, 1 = test failures or no results, 2 = crash.
+	/// </summary>
+	internal static int OutcomeToExitCode(TestRunOutcome outcome, int failedCount) =>
+		outcome switch
+		{
+			TestRunOutcome.Crashed => 2,
+			TestRunOutcome.NoResults => 1,
+			TestRunOutcome.CleanEmpty => 0,
+			_ => failedCount > 0 ? 1 : 0,
+		};
+
+	/// <summary>
 	/// Parses a logger string in the format "name" or "name;LogFileName=file.ext"
 	/// matching dotnet test --logger conventions.
 	/// </summary>

--- a/src/DeviceRunners.Cli/Commands/BaseTestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/BaseTestCommand.cs
@@ -49,6 +49,10 @@ public abstract class BaseTestCommand<TSettings>(IAnsiConsole console) : BaseCom
 		[CommandOption("--data-timeout")]
 		[DefaultValue(30)]
 		public int DataTimeout { get; set; } = 30;
+
+		[Description("Run only the tests matching the given dotnet test --filter style expression")]
+		[CommandOption("--filter")]
+		public string? Filter { get; set; }
 	}
 
 	public override int Execute(CommandContext context, TSettings settings, CancellationToken cancellationToken)
@@ -62,12 +66,20 @@ public abstract class BaseTestCommand<TSettings>(IAnsiConsole console) : BaseCom
 	/// Builds the environment variables that tell the test app how to connect
 	/// back to the CLI's TCP listener.
 	/// </summary>
-	protected static Dictionary<string, string> GetAppEnvironmentVariables(TSettings settings) => new()
+	internal static Dictionary<string, string> GetAppEnvironmentVariables(TSettings settings)
 	{
-		["DEVICE_RUNNERS_AUTORUN"] = "1",
-		["DEVICE_RUNNERS_PORT"] = (settings.AppPort ?? settings.Port).ToString(),
-		["DEVICE_RUNNERS_HOST_NAMES"] = settings.AppHostNames ?? "localhost",
-	};
+		var variables = new Dictionary<string, string>
+		{
+			["DEVICE_RUNNERS_AUTORUN"] = "1",
+			["DEVICE_RUNNERS_PORT"] = (settings.AppPort ?? settings.Port).ToString(),
+			["DEVICE_RUNNERS_HOST_NAMES"] = settings.AppHostNames ?? "localhost",
+		};
+
+		if (!string.IsNullOrWhiteSpace(settings.Filter))
+			variables["DEVICE_RUNNERS_FILTER"] = settings.Filter!;
+
+		return variables;
+	}
 
 	protected record TestListenerResult(int FailedCount, string? ResultsFile, bool Crashed)
 	{

--- a/src/DeviceRunners.Cli/Commands/BaseTestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/BaseTestCommand.cs
@@ -210,7 +210,9 @@ public abstract class BaseTestCommand<TSettings>(IAnsiConsole console) : BaseCom
 		// Detect app crash: if we received a "begin" event and test results but
 		// never got the "end" event, the app crashed or was killed mid-run.
 		// Return -1 to signal crash to the caller (mapped to exit code 2).
-		if (eventStream.HasStarted && !eventStream.HasEnded && eventStream.TotalCount > 0)
+		var outcome = ClassifyRun(eventStream.HasStarted, eventStream.HasEnded, eventStream.TotalCount);
+
+		if (outcome == TestRunOutcome.Crashed)
 		{
 			WriteConsoleOutput($"    [red]The application appears to have crashed during the test run.[/]", settings);
 			WriteConsoleOutput($"    [red]Only {eventStream.TotalCount} test result(s) were received before the connection was lost.[/]", settings);
@@ -218,13 +220,57 @@ public abstract class BaseTestCommand<TSettings>(IAnsiConsole console) : BaseCom
 			return new TestListenerResult(eventStream.FailedCount, resultsFile, Crashed: true);
 		}
 
-		if (eventStream.TotalCount == 0)
+		// A clean empty run (begin + end received, but no test results) is a success,
+		// not a failure — it mirrors `dotnet test --filter`, which exits 0 with
+		// "No test matches the given testcase filter". Only treat a missing connection
+		// (no "begin" event at all) as a failure.
+		if (outcome == TestRunOutcome.CleanEmpty)
+		{
+			WriteConsoleOutput($"    [yellow]No test matches the given test filter. The run completed with no results.[/]", settings);
+			return new TestListenerResult(0, resultsFile, Crashed: false);
+		}
+
+		if (outcome == TestRunOutcome.NoResults)
 		{
 			WriteConsoleOutput($"    [yellow]No test results received.[/]", settings);
 			return new TestListenerResult(1, null, Crashed: false);
 		}
 
 		return new TestListenerResult(eventStream.FailedCount, resultsFile, Crashed: false);
+	}
+
+	internal enum TestRunOutcome
+	{
+		/// <summary>Begin, results, and end were all received — a normal run.</summary>
+		Completed,
+
+		/// <summary>Begin and end received with zero results — a successful empty run (e.g. a zero-match filter).</summary>
+		CleanEmpty,
+
+		/// <summary>Begin and results received but no end — the app crashed mid-run.</summary>
+		Crashed,
+
+		/// <summary>No connection or no begin event — the app never reported a run.</summary>
+		NoResults,
+	}
+
+	/// <summary>
+	/// Classifies a test run from the event-stream flags, distinguishing a clean
+	/// empty run (zero-match filter, still a success) from a crash or a missing
+	/// connection.
+	/// </summary>
+	internal static TestRunOutcome ClassifyRun(bool hasStarted, bool hasEnded, int totalCount)
+	{
+		if (hasStarted && !hasEnded && totalCount > 0)
+			return TestRunOutcome.Crashed;
+
+		if (hasStarted && hasEnded && totalCount == 0)
+			return TestRunOutcome.CleanEmpty;
+
+		if (totalCount == 0)
+			return TestRunOutcome.NoResults;
+
+		return TestRunOutcome.Completed;
 	}
 
 	/// <summary>

--- a/src/DeviceRunners.Cli/Commands/Wasm/WasmTestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Wasm/WasmTestCommand.cs
@@ -166,28 +166,39 @@ public class WasmTestCommand(IAnsiConsole console) : BaseTestCommand<WasmTestCom
 
 			WriteConsoleOutput($"  - Results: Total={eventStream.TotalCount}, Passed={eventStream.PassedCount}, Failed={eventStream.FailedCount}, Skipped={eventStream.SkippedCount}", settings);
 
-			// A clean empty run (begin + end received, but no test results) is a success,
-			// mirroring `dotnet test --filter` exit 0. Only a missing run (no "begin"
-			// event) is treated as a failure.
-			var cleanEmptyRun = ClassifyRun(eventStream.HasStarted, eventStream.HasEnded, eventStream.TotalCount) == TestRunOutcome.CleanEmpty;
+			// Classify the run the same way the TCP listener does so a crash or
+			// timeout mid-run (begin + some results, but no "end") is reported as a
+			// failure instead of being mistaken for a successful run. A clean empty
+			// run (begin + end, no results) still succeeds, mirroring `dotnet test
+			// --filter` exit 0.
+			var outcome = ClassifyRun(eventStream.HasStarted, eventStream.HasEnded, eventStream.TotalCount);
 
-			if (eventStream.TotalCount == 0 && !cleanEmptyRun)
+			if (outcome == TestRunOutcome.Crashed)
+				WriteConsoleOutput($"    [red]The app crashed or timed out before the run completed. Only {eventStream.TotalCount} test result(s) were received before the connection was lost. Check browser-console.log for details.[/]", settings);
+			else if (outcome == TestRunOutcome.NoResults)
 				WriteConsoleOutput($"    [red]No test results received. This usually means the browser failed to navigate, the app didn't boot, or the autorun query parameter was not detected. Check browser-console.log for details.[/]", settings);
-			else if (cleanEmptyRun)
+			else if (outcome == TestRunOutcome.CleanEmpty)
 				WriteConsoleOutput($"    [yellow]No test matches the given test filter. The run completed with no results.[/]", settings);
+
+			var errorMessage = outcome switch
+			{
+				TestRunOutcome.Crashed => "The app crashed or timed out mid-run — check browser-console.log",
+				TestRunOutcome.NoResults => "No test results received — check browser-console.log",
+				_ => (string?)null,
+			};
 
 			var result = new TestStartResult
 			{
-				Success = eventStream.FailedCount == 0 && (eventStream.TotalCount > 0 || cleanEmptyRun),
+				Success = OutcomeIsSuccess(outcome, eventStream.FailedCount),
 				AppPath = settings.App,
 				ResultsDirectory = settings.ResultsDirectory,
 				TestFailures = eventStream.FailedCount,
 				TestResults = resultsFile,
-				ErrorMessage = eventStream.TotalCount == 0 && !cleanEmptyRun ? "No test results received — check browser-console.log" : null
+				ErrorMessage = errorMessage
 			};
 			WriteResult(result, settings);
 
-			return eventStream.FailedCount > 0 || (eventStream.TotalCount == 0 && !cleanEmptyRun) ? 1 : 0;
+			return OutcomeToExitCode(outcome, eventStream.FailedCount);
 		}
 		catch (Exception ex)
 		{

--- a/src/DeviceRunners.Cli/Commands/Wasm/WasmTestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Wasm/WasmTestCommand.cs
@@ -166,21 +166,28 @@ public class WasmTestCommand(IAnsiConsole console) : BaseTestCommand<WasmTestCom
 
 			WriteConsoleOutput($"  - Results: Total={eventStream.TotalCount}, Passed={eventStream.PassedCount}, Failed={eventStream.FailedCount}, Skipped={eventStream.SkippedCount}", settings);
 
-			if (eventStream.TotalCount == 0)
+			// A clean empty run (begin + end received, but no test results) is a success,
+			// mirroring `dotnet test --filter` exit 0. Only a missing run (no "begin"
+			// event) is treated as a failure.
+			var cleanEmptyRun = ClassifyRun(eventStream.HasStarted, eventStream.HasEnded, eventStream.TotalCount) == TestRunOutcome.CleanEmpty;
+
+			if (eventStream.TotalCount == 0 && !cleanEmptyRun)
 				WriteConsoleOutput($"    [red]No test results received. This usually means the browser failed to navigate, the app didn't boot, or the autorun query parameter was not detected. Check browser-console.log for details.[/]", settings);
+			else if (cleanEmptyRun)
+				WriteConsoleOutput($"    [yellow]No test matches the given test filter. The run completed with no results.[/]", settings);
 
 			var result = new TestStartResult
 			{
-				Success = eventStream.FailedCount == 0 && eventStream.TotalCount > 0,
+				Success = eventStream.FailedCount == 0 && (eventStream.TotalCount > 0 || cleanEmptyRun),
 				AppPath = settings.App,
 				ResultsDirectory = settings.ResultsDirectory,
 				TestFailures = eventStream.FailedCount,
 				TestResults = resultsFile,
-				ErrorMessage = eventStream.TotalCount == 0 ? "No test results received — check browser-console.log" : null
+				ErrorMessage = eventStream.TotalCount == 0 && !cleanEmptyRun ? "No test results received — check browser-console.log" : null
 			};
 			WriteResult(result, settings);
 
-			return eventStream.FailedCount > 0 || eventStream.TotalCount == 0 ? 1 : 0;
+			return eventStream.FailedCount > 0 || (eventStream.TotalCount == 0 && !cleanEmptyRun) ? 1 : 0;
 		}
 		catch (Exception ex)
 		{

--- a/src/DeviceRunners.Cli/Commands/Wasm/WasmTestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Wasm/WasmTestCommand.cs
@@ -134,6 +134,8 @@ public class WasmTestCommand(IAnsiConsole console) : BaseTestCommand<WasmTestCom
 			};
 
 			var testUrl = $"{url}?device-runners-autorun=1";
+			if (!string.IsNullOrWhiteSpace(settings.Filter))
+				testUrl += $"&device-runners-filter={Uri.EscapeDataString(settings.Filter)}";
 			await browser.LaunchAsync(testUrl, headless: !settings.Headed);
 			WriteConsoleOutput($"    Browser launched, running tests...", settings);
 

--- a/src/DeviceRunners.Cli/Commands/Windows/TestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Windows/TestCommand.cs
@@ -170,6 +170,8 @@ public class WindowsTestCommand(IAnsiConsole console) : BaseTestCommand<WindowsT
 			var appPort = settings.AppPort ?? settings.Port;
 			var appHostNames = settings.AppHostNames ?? "localhost";
 			var appArgs = $"--device-runners-autorun --device-runners-port {appPort} --device-runners-host-names {appHostNames}";
+			if (!string.IsNullOrWhiteSpace(settings.Filter))
+				appArgs += $" --device-runners-filter \"{settings.Filter}\"";
 			pid = await winAppService.RunDetachedAsync(inputFolder, manifestPath, appArgs: appArgs);
 		}
 		catch (Exception ex)

--- a/src/DeviceRunners.Testing.Targets/build/DeviceRunners.Testing.Targets.targets
+++ b/src/DeviceRunners.Testing.Targets/build/DeviceRunners.Testing.Targets.targets
@@ -122,8 +122,15 @@
       <_DeviceRunnersLoggerArg />
       <_DeviceRunnersLoggerArg Condition="'$(VSTestLogger)' != ''"> --logger &quot;$(VSTestLogger)&quot;</_DeviceRunnersLoggerArg>
 
+      <!--
+        Forward the test filter from "dotnet test ‑‑filter" ($(VSTestTestCaseFilter))
+        when present, so a single test or class can be selected on-device.
+      -->
+      <_DeviceRunnersFilterArg />
+      <_DeviceRunnersFilterArg Condition="'$(VSTestTestCaseFilter)' != ''"> --filter &quot;$(VSTestTestCaseFilter)&quot;</_DeviceRunnersFilterArg>
+
       <!-- Flags shared by every platform sub-command. -->
-      <_DeviceRunnersCommonCliArgs>--results-directory &quot;$(_DeviceRunnersResultsDir)&quot; --port $(DeviceRunnersPort) --connection-timeout $(DeviceRunnersConnectionTimeout) --data-timeout $(DeviceRunnersDataTimeout)$(_DeviceRunnersLoggerArg)</_DeviceRunnersCommonCliArgs>
+      <_DeviceRunnersCommonCliArgs>--results-directory &quot;$(_DeviceRunnersResultsDir)&quot; --port $(DeviceRunnersPort) --connection-timeout $(DeviceRunnersConnectionTimeout) --data-timeout $(DeviceRunnersDataTimeout)$(_DeviceRunnersLoggerArg)$(_DeviceRunnersFilterArg)</_DeviceRunnersCommonCliArgs>
     </PropertyGroup>
     <MakeDir Directories="$(_DeviceRunnersResultsDir)" />
   </Target>
@@ -243,7 +250,7 @@
            Condition="!Exists('$(_DeviceRunnersWasmDir)')" />
     <PropertyGroup>
       <!-- WASM uses different CLI flags: no port/TCP, instead uses browser console capture -->
-      <_DeviceRunnersCliArgs>wasm test --app &quot;$(_DeviceRunnersWasmDir)&quot; --results-directory &quot;$(_DeviceRunnersResultsDir)&quot;$(_DeviceRunnersLoggerArg) --timeout $(DeviceRunnersWasmTimeout)</_DeviceRunnersCliArgs>
+      <_DeviceRunnersCliArgs>wasm test --app &quot;$(_DeviceRunnersWasmDir)&quot; --results-directory &quot;$(_DeviceRunnersResultsDir)&quot;$(_DeviceRunnersLoggerArg)$(_DeviceRunnersFilterArg) --timeout $(DeviceRunnersWasmTimeout)</_DeviceRunnersCliArgs>
     </PropertyGroup>
     <Message Importance="high" Text="DeviceRunners: running WASM browser tests from $(_DeviceRunnersWasmDir)" />
   </Target>
@@ -399,6 +406,7 @@
       <_GeneratedAndroidEnvironment Include="DEVICE_RUNNERS_AUTORUN=1" />
       <_GeneratedAndroidEnvironment Include="DEVICE_RUNNERS_PORT=$(DeviceRunnersPort)" />
       <_GeneratedAndroidEnvironment Include="DEVICE_RUNNERS_HOST_NAMES=localhost%3B10.0.2.2" />
+      <_GeneratedAndroidEnvironment Include="DEVICE_RUNNERS_FILTER=$(VSTestTestCaseFilter)" Condition="'$(VSTestTestCaseFilter)' != ''" />
     </ItemGroup>
   </Target>
 

--- a/src/DeviceRunners.VisualRunners.Blazor/VisualTestRunnerConfigurationBuilder.cs
+++ b/src/DeviceRunners.VisualRunners.Blazor/VisualTestRunnerConfigurationBuilder.cs
@@ -15,6 +15,7 @@ public class VisualTestRunnerConfigurationBuilder : IVisualTestRunnerConfigurati
 	readonly List<Assembly> _assemblies = [];
 	bool _autoStart;
 	bool _autoTerminate;
+	string? _testCaseFilter;
 
 	public VisualTestRunnerConfigurationBuilder(IServiceCollection services)
 	{
@@ -36,11 +37,14 @@ public class VisualTestRunnerConfigurationBuilder : IVisualTestRunnerConfigurati
 		_autoTerminate = autoTerminate;
 	}
 
+	void IVisualTestRunnerConfigurationBuilder.SetTestCaseFilter(string? filter) =>
+		_testCaseFilter = string.IsNullOrWhiteSpace(filter) ? null : filter;
+
 	void IVisualTestRunnerConfigurationBuilder.AddResultChannel<T>(Func<IServiceProvider, T> creator) =>
 		_services.AddSingleton<IResultChannel>(svc => creator(svc));
 
 	IVisualTestRunnerConfiguration IVisualTestRunnerConfigurationBuilder.Build() => Build();
 
 	public VisualTestRunnerConfiguration Build() =>
-		new(_assemblies, _autoStart, _autoTerminate);
+		new(_assemblies, _autoStart, _autoTerminate, _testCaseFilter);
 }

--- a/src/DeviceRunners.VisualRunners.Blazor/VisualTestRunnerConfigurationBuilderExtensions.cs
+++ b/src/DeviceRunners.VisualRunners.Blazor/VisualTestRunnerConfigurationBuilderExtensions.cs
@@ -18,6 +18,7 @@ public static class VisualTestRunnerConfigurationBuilderExtensions
 		where TBuilder : IVisualTestRunnerConfigurationBuilder
 	{
 		string? autorun = null;
+		string? filter = null;
 
 		try
 		{
@@ -33,6 +34,8 @@ public static class VisualTestRunnerConfigurationBuilderExtensions
 
 					if (key.Equals("device-runners-autorun", StringComparison.OrdinalIgnoreCase))
 						autorun = value;
+					else if (key.Equals("device-runners-filter", StringComparison.OrdinalIgnoreCase))
+						filter = value;
 				}
 			}
 		}
@@ -45,6 +48,7 @@ public static class VisualTestRunnerConfigurationBuilderExtensions
 			return builder;
 
 		builder.EnableAutoStart(autoTerminate: true);
+		builder.SetTestCaseFilter(filter);
 		builder.AddResultChannel(_ => new ConsoleResultChannel(new EventStreamFormatter()));
 		return builder;
 	}

--- a/src/DeviceRunners.VisualRunners.Core/Testing/Channels/TestResultEvent.cs
+++ b/src/DeviceRunners.VisualRunners.Core/Testing/Channels/TestResultEvent.cs
@@ -185,6 +185,11 @@ public record TestResultEvent
 		public ITestAssemblyInfo TestAssembly { get; } = new ParsedTestAssemblyInfo(assemblyFileName);
 		public string DisplayName { get; } = displayName;
 		public ITestResultInfo? Result => null;
+		public string? TestClassName => null;
+		public string? TestMethodName => null;
+		public string? TestClassNamespace => null;
+		public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; } =
+			new Dictionary<string, IReadOnlyList<string>>();
 		public event Action<ITestResultInfo>? ResultReported { add { } remove { } }
 	}
 

--- a/src/DeviceRunners.VisualRunners.Core/Testing/ITestCaseInfo.cs
+++ b/src/DeviceRunners.VisualRunners.Core/Testing/ITestCaseInfo.cs
@@ -2,46 +2,46 @@ namespace DeviceRunners.VisualRunners;
 
 public interface ITestCaseInfo
 {
-ITestAssemblyInfo TestAssembly { get; }
+	ITestAssemblyInfo TestAssembly { get; }
 
-string DisplayName { get; }
+	string DisplayName { get; }
 
-ITestResultInfo? Result { get; }
+	ITestResultInfo? Result { get; }
 
-event Action<ITestResultInfo>? ResultReported;
+	event Action<ITestResultInfo>? ResultReported;
 
-/// <summary>
-/// The fully qualified test class name (e.g. "MyNamespace.MyClass"), when available.
-/// </summary>
-string? TestClassName => null;
+	/// <summary>
+	/// The fully qualified test class name (e.g. "MyNamespace.MyClass"), when available.
+	/// </summary>
+	string? TestClassName => null;
 
-/// <summary>
-/// The test method name (e.g. "MyMethod"), when available.
-/// </summary>
-string? TestMethodName => null;
+	/// <summary>
+	/// The test method name (e.g. "MyMethod"), when available.
+	/// </summary>
+	string? TestMethodName => null;
 
-/// <summary>
-/// The namespace of the test class (e.g. "MyNamespace"). Derived from
-/// <see cref="TestClassName"/> unless an implementation provides a better value.
-/// </summary>
-string? TestClassNamespace
-{
-get
-{
-var className = TestClassName;
-if (string.IsNullOrEmpty(className))
-return null;
+	/// <summary>
+	/// The namespace of the test class (e.g. "MyNamespace"). Derived from
+	/// <see cref="TestClassName"/> unless an implementation provides a better value.
+	/// </summary>
+	string? TestClassNamespace
+	{
+		get
+		{
+			var className = TestClassName;
+			if (string.IsNullOrEmpty(className))
+				return null;
 
-var index = className!.LastIndexOf('.');
-return index > 0 ? className.Substring(0, index) : null;
-}
-}
+			var index = className!.LastIndexOf('.');
+			return index > 0 ? className.Substring(0, index) : null;
+		}
+	}
 
-/// <summary>
-/// The traits (categories) associated with the test case, keyed by trait name.
-/// </summary>
-IReadOnlyDictionary<string, IReadOnlyList<string>> Traits => EmptyTraits;
+	/// <summary>
+	/// The traits (categories) associated with the test case, keyed by trait name.
+	/// </summary>
+	IReadOnlyDictionary<string, IReadOnlyList<string>> Traits => EmptyTraits;
 
-private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyTraits =
-new Dictionary<string, IReadOnlyList<string>>();
+	private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyTraits =
+		new Dictionary<string, IReadOnlyList<string>>();
 }

--- a/src/DeviceRunners.VisualRunners.Core/Testing/ITestCaseInfo.cs
+++ b/src/DeviceRunners.VisualRunners.Core/Testing/ITestCaseInfo.cs
@@ -13,35 +13,20 @@ public interface ITestCaseInfo
 	/// <summary>
 	/// The fully qualified test class name (e.g. "MyNamespace.MyClass"), when available.
 	/// </summary>
-	string? TestClassName => null;
+	string? TestClassName { get; }
 
 	/// <summary>
 	/// The test method name (e.g. "MyMethod"), when available.
 	/// </summary>
-	string? TestMethodName => null;
+	string? TestMethodName { get; }
 
 	/// <summary>
-	/// The namespace of the test class (e.g. "MyNamespace"). Derived from
-	/// <see cref="TestClassName"/> unless an implementation provides a better value.
+	/// The namespace of the test class (e.g. "MyNamespace"), when available.
 	/// </summary>
-	string? TestClassNamespace
-	{
-		get
-		{
-			var className = TestClassName;
-			if (string.IsNullOrEmpty(className))
-				return null;
-
-			var index = className!.LastIndexOf('.');
-			return index > 0 ? className.Substring(0, index) : null;
-		}
-	}
+	string? TestClassNamespace { get; }
 
 	/// <summary>
 	/// The traits (categories) associated with the test case, keyed by trait name.
 	/// </summary>
-	IReadOnlyDictionary<string, IReadOnlyList<string>> Traits => EmptyTraits;
-
-	private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyTraits =
-		new Dictionary<string, IReadOnlyList<string>>();
+	IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; }
 }

--- a/src/DeviceRunners.VisualRunners.Core/Testing/ITestCaseInfo.cs
+++ b/src/DeviceRunners.VisualRunners.Core/Testing/ITestCaseInfo.cs
@@ -2,11 +2,46 @@ namespace DeviceRunners.VisualRunners;
 
 public interface ITestCaseInfo
 {
-	ITestAssemblyInfo TestAssembly { get; }
+ITestAssemblyInfo TestAssembly { get; }
 
-	string DisplayName { get; }
+string DisplayName { get; }
 
-	ITestResultInfo? Result { get; }
+ITestResultInfo? Result { get; }
 
-	event Action<ITestResultInfo>? ResultReported;
+event Action<ITestResultInfo>? ResultReported;
+
+/// <summary>
+/// The fully qualified test class name (e.g. "MyNamespace.MyClass"), when available.
+/// </summary>
+string? TestClassName => null;
+
+/// <summary>
+/// The test method name (e.g. "MyMethod"), when available.
+/// </summary>
+string? TestMethodName => null;
+
+/// <summary>
+/// The namespace of the test class (e.g. "MyNamespace"). Derived from
+/// <see cref="TestClassName"/> unless an implementation provides a better value.
+/// </summary>
+string? TestClassNamespace
+{
+get
+{
+var className = TestClassName;
+if (string.IsNullOrEmpty(className))
+return null;
+
+var index = className!.LastIndexOf('.');
+return index > 0 ? className.Substring(0, index) : null;
+}
+}
+
+/// <summary>
+/// The traits (categories) associated with the test case, keyed by trait name.
+/// </summary>
+IReadOnlyDictionary<string, IReadOnlyList<string>> Traits => EmptyTraits;
+
+private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyTraits =
+new Dictionary<string, IReadOnlyList<string>>();
 }

--- a/src/DeviceRunners.VisualRunners.Maui/VisualTestRunnerConfigurationBuilder.cs
+++ b/src/DeviceRunners.VisualRunners.Maui/VisualTestRunnerConfigurationBuilder.cs
@@ -9,6 +9,7 @@ public class VisualTestRunnerConfigurationBuilder : IVisualTestRunnerConfigurati
 	readonly List<Func<ResourceDictionary>> _resourceDictionaryFactories = new();
 	bool _autoStart;
 	bool _autoTerminate;
+	string? _testCaseFilter;
 
 	public VisualTestRunnerConfigurationBuilder(MauiAppBuilder appHostBuilder)
 	{
@@ -63,6 +64,9 @@ public class VisualTestRunnerConfigurationBuilder : IVisualTestRunnerConfigurati
 		_autoTerminate = autoTerminate;
 	}
 
+	void IVisualTestRunnerConfigurationBuilder.SetTestCaseFilter(string? filter) =>
+		_testCaseFilter = string.IsNullOrWhiteSpace(filter) ? null : filter;
+
 	void IVisualTestRunnerConfigurationBuilder.AddResultChannel<T>(Func<IServiceProvider, T> creator) =>
 		_appHostBuilder.Services.AddSingleton<IResultChannel>(svc => creator(svc));
 
@@ -70,5 +74,5 @@ public class VisualTestRunnerConfigurationBuilder : IVisualTestRunnerConfigurati
 		Build();
 
 	public VisualTestRunnerConfiguration Build() =>
-		new(_testAssemblies, _autoStart, _autoTerminate);
+		new(_testAssemblies, _autoStart, _autoTerminate, _testCaseFilter);
 }

--- a/src/DeviceRunners.VisualRunners.Maui/VisualTestRunnerConfigurationBuilderExtensions.cs
+++ b/src/DeviceRunners.VisualRunners.Maui/VisualTestRunnerConfigurationBuilderExtensions.cs
@@ -25,6 +25,7 @@ public static class VisualTestRunnerConfigurationBuilderExtensions
 		var autorun = Environment.GetEnvironmentVariable("DEVICE_RUNNERS_AUTORUN");
 		var portStr = Environment.GetEnvironmentVariable("DEVICE_RUNNERS_PORT");
 		var hostNamesRaw = Environment.GetEnvironmentVariable("DEVICE_RUNNERS_HOST_NAMES");
+		var filter = Environment.GetEnvironmentVariable("DEVICE_RUNNERS_FILTER");
 
 		// Fall back to CLI arguments (for MSIX where env vars are not forwarded)
 		if (string.IsNullOrEmpty(autorun))
@@ -38,6 +39,8 @@ public static class VisualTestRunnerConfigurationBuilderExtensions
 					portStr = args[++i];
 				else if (args[i] == "--device-runners-host-names" && i + 1 < args.Length)
 					hostNamesRaw = args[++i];
+				else if (args[i] == "--device-runners-filter" && i + 1 < args.Length)
+					filter = args[++i];
 			}
 		}
 
@@ -50,6 +53,7 @@ public static class VisualTestRunnerConfigurationBuilderExtensions
 			: hostNamesRaw.Split(';', StringSplitOptions.RemoveEmptyEntries);
 
 		builder.EnableAutoStart(autoTerminate: true);
+		builder.SetTestCaseFilter(filter);
 		builder.AddTcpResultChannel(new TcpResultChannelOptions
 		{
 			HostNames = hostNames,

--- a/src/DeviceRunners.VisualRunners.NUnit/NUnitTestCaseInfo.cs
+++ b/src/DeviceRunners.VisualRunners.NUnit/NUnitTestCaseInfo.cs
@@ -11,6 +11,7 @@ class NUnitTestCaseInfo : ITestCaseInfo
 
 		TestClassName = testCase.ClassName;
 		TestMethodName = testCase.MethodName;
+		TestClassNamespace = GetNamespace(TestClassName);
 		Traits = ConvertTraits(testCase.Properties);
 	}
 
@@ -26,7 +27,7 @@ class NUnitTestCaseInfo : ITestCaseInfo
 
 	public string? TestMethodName { get; }
 
-	public string? TestClassNamespace => GetNamespace(TestClassName);
+	public string? TestClassNamespace { get; }
 
 	public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; }
 

--- a/src/DeviceRunners.VisualRunners.NUnit/NUnitTestCaseInfo.cs
+++ b/src/DeviceRunners.VisualRunners.NUnit/NUnitTestCaseInfo.cs
@@ -8,6 +8,10 @@ class NUnitTestCaseInfo : ITestCaseInfo
 	{
 		TestAssembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
 		TestCase = testCase ?? throw new ArgumentNullException(nameof(testCase));
+
+		TestClassName = testCase.ClassName;
+		TestMethodName = testCase.MethodName;
+		Traits = ConvertTraits(testCase.Properties);
 	}
 
 	public NUnitTestAssemblyInfo TestAssembly { get; }
@@ -17,6 +21,12 @@ class NUnitTestCaseInfo : ITestCaseInfo
 	public string AssemblyFileName => TestAssembly.AssemblyFileName;
 
 	public string DisplayName => TestCase.FullName;
+
+	public string? TestClassName { get; }
+
+	public string? TestMethodName { get; }
+
+	public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; }
 
 	public ITest TestCase { get; }
 
@@ -31,5 +41,26 @@ class NUnitTestCaseInfo : ITestCaseInfo
 		Result = result;
 
 		ResultReported?.Invoke(result);
+	}
+
+	static IReadOnlyDictionary<string, IReadOnlyList<string>> ConvertTraits(IPropertyBag? properties)
+	{
+		if (properties is null || properties.Keys.Count == 0)
+			return new Dictionary<string, IReadOnlyList<string>>();
+
+		var result = new Dictionary<string, IReadOnlyList<string>>(properties.Keys.Count);
+		foreach (var key in properties.Keys)
+		{
+			var values = new List<string>();
+			foreach (var value in properties[key])
+			{
+				if (value is not null)
+					values.Add(value.ToString()!);
+			}
+
+			result[key] = values;
+		}
+
+		return result;
 	}
 }

--- a/src/DeviceRunners.VisualRunners.NUnit/NUnitTestCaseInfo.cs
+++ b/src/DeviceRunners.VisualRunners.NUnit/NUnitTestCaseInfo.cs
@@ -26,6 +26,8 @@ class NUnitTestCaseInfo : ITestCaseInfo
 
 	public string? TestMethodName { get; }
 
+	public string? TestClassNamespace => GetNamespace(TestClassName);
+
 	public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; }
 
 	public ITest TestCase { get; }
@@ -41,6 +43,15 @@ class NUnitTestCaseInfo : ITestCaseInfo
 		Result = result;
 
 		ResultReported?.Invoke(result);
+	}
+
+	static string? GetNamespace(string? className)
+	{
+		if (string.IsNullOrEmpty(className))
+			return null;
+
+		var index = className!.LastIndexOf('.');
+		return index > 0 ? className.Substring(0, index) : null;
 	}
 
 	static IReadOnlyDictionary<string, IReadOnlyList<string>> ConvertTraits(IPropertyBag? properties)

--- a/src/DeviceRunners.VisualRunners.Xunit/XunitTestCaseInfo.cs
+++ b/src/DeviceRunners.VisualRunners.Xunit/XunitTestCaseInfo.cs
@@ -8,6 +8,10 @@ class XunitTestCaseInfo : ITestCaseInfo
 	{
 		TestAssembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
 		TestCase = testCase ?? throw new ArgumentNullException(nameof(testCase));
+
+		TestClassName = testCase.TestMethod?.TestClass?.Class?.Name;
+		TestMethodName = testCase.TestMethod?.Method?.Name;
+		Traits = ConvertTraits(testCase.Traits);
 	}
 
 	public XunitTestAssemblyInfo TestAssembly { get; }
@@ -17,6 +21,12 @@ class XunitTestCaseInfo : ITestCaseInfo
 	public string AssemblyFileName => TestAssembly.AssemblyFileName;
 
 	public string DisplayName => TestCase.DisplayName;
+
+	public string? TestClassName { get; }
+
+	public string? TestMethodName { get; }
+
+	public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; }
 
 	public ITestCase TestCase { get; }
 
@@ -31,5 +41,17 @@ class XunitTestCaseInfo : ITestCaseInfo
 		Result = result;
 
 		ResultReported?.Invoke(result);
+	}
+
+	static IReadOnlyDictionary<string, IReadOnlyList<string>> ConvertTraits(Dictionary<string, List<string>>? traits)
+	{
+		if (traits is null || traits.Count == 0)
+			return new Dictionary<string, IReadOnlyList<string>>();
+
+		var result = new Dictionary<string, IReadOnlyList<string>>(traits.Count);
+		foreach (var pair in traits)
+			result[pair.Key] = pair.Value;
+
+		return result;
 	}
 }

--- a/src/DeviceRunners.VisualRunners.Xunit/XunitTestCaseInfo.cs
+++ b/src/DeviceRunners.VisualRunners.Xunit/XunitTestCaseInfo.cs
@@ -11,6 +11,7 @@ class XunitTestCaseInfo : ITestCaseInfo
 
 		TestClassName = testCase.TestMethod?.TestClass?.Class?.Name;
 		TestMethodName = testCase.TestMethod?.Method?.Name;
+		TestClassNamespace = GetNamespace(TestClassName);
 		Traits = ConvertTraits(testCase.Traits);
 	}
 
@@ -26,7 +27,7 @@ class XunitTestCaseInfo : ITestCaseInfo
 
 	public string? TestMethodName { get; }
 
-	public string? TestClassNamespace => GetNamespace(TestClassName);
+	public string? TestClassNamespace { get; }
 
 	public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; }
 

--- a/src/DeviceRunners.VisualRunners.Xunit/XunitTestCaseInfo.cs
+++ b/src/DeviceRunners.VisualRunners.Xunit/XunitTestCaseInfo.cs
@@ -26,6 +26,8 @@ class XunitTestCaseInfo : ITestCaseInfo
 
 	public string? TestMethodName { get; }
 
+	public string? TestClassNamespace => GetNamespace(TestClassName);
+
 	public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; }
 
 	public ITestCase TestCase { get; }
@@ -41,6 +43,15 @@ class XunitTestCaseInfo : ITestCaseInfo
 		Result = result;
 
 		ResultReported?.Invoke(result);
+	}
+
+	static string? GetNamespace(string? className)
+	{
+		if (string.IsNullOrEmpty(className))
+			return null;
+
+		var index = className!.LastIndexOf('.');
+		return index > 0 ? className.Substring(0, index) : null;
 	}
 
 	static IReadOnlyDictionary<string, IReadOnlyList<string>> ConvertTraits(Dictionary<string, List<string>>? traits)

--- a/src/DeviceRunners.VisualRunners.Xunit3/Xunit3TestCaseInfo.cs
+++ b/src/DeviceRunners.VisualRunners.Xunit3/Xunit3TestCaseInfo.cs
@@ -12,6 +12,7 @@ class Xunit3TestCaseInfo : ITestCaseInfo
 		DisplayName = testCase.TestCaseDisplayName;
 		TestClassName = testCase.TestClassName;
 		TestMethodName = testCase.TestMethodName;
+		TestClassNamespace = GetNamespace(TestClassName);
 		Traits = ConvertTraits(testCase.Traits);
 	}
 
@@ -48,7 +49,7 @@ class Xunit3TestCaseInfo : ITestCaseInfo
 	/// <summary>
 	/// The namespace of the test class (e.g. "MyNamespace").
 	/// </summary>
-	public string? TestClassNamespace => GetNamespace(TestClassName);
+	public string? TestClassNamespace { get; }
 
 	/// <summary>
 	/// The traits associated with this test case.

--- a/src/DeviceRunners.VisualRunners.Xunit3/Xunit3TestCaseInfo.cs
+++ b/src/DeviceRunners.VisualRunners.Xunit3/Xunit3TestCaseInfo.cs
@@ -46,6 +46,11 @@ class Xunit3TestCaseInfo : ITestCaseInfo
 	public string? TestMethodName { get; }
 
 	/// <summary>
+	/// The namespace of the test class (e.g. "MyNamespace").
+	/// </summary>
+	public string? TestClassNamespace => GetNamespace(TestClassName);
+
+	/// <summary>
 	/// The traits associated with this test case.
 	/// </summary>
 	public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; }
@@ -61,6 +66,15 @@ class Xunit3TestCaseInfo : ITestCaseInfo
 		Result = result;
 
 		ResultReported?.Invoke(result);
+	}
+
+	static string? GetNamespace(string? className)
+	{
+		if (string.IsNullOrEmpty(className))
+			return null;
+
+		var index = className!.LastIndexOf('.');
+		return index > 0 ? className.Substring(0, index) : null;
 	}
 
 	static IReadOnlyDictionary<string, IReadOnlyList<string>> ConvertTraits(IReadOnlyDictionary<string, IReadOnlyCollection<string>>? traits)

--- a/src/DeviceRunners.VisualRunners.Xunit3/Xunit3TestCaseInfo.cs
+++ b/src/DeviceRunners.VisualRunners.Xunit3/Xunit3TestCaseInfo.cs
@@ -12,6 +12,7 @@ class Xunit3TestCaseInfo : ITestCaseInfo
 		DisplayName = testCase.TestCaseDisplayName;
 		TestClassName = testCase.TestClassName;
 		TestMethodName = testCase.TestMethodName;
+		Traits = ConvertTraits(testCase.Traits);
 	}
 
 	public Xunit3TestAssemblyInfo TestAssembly { get; }
@@ -44,6 +45,11 @@ class Xunit3TestCaseInfo : ITestCaseInfo
 	/// </summary>
 	public string? TestMethodName { get; }
 
+	/// <summary>
+	/// The traits associated with this test case.
+	/// </summary>
+	public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; }
+
 	public Xunit3TestResultInfo? Result { get; private set; }
 
 	ITestResultInfo? ITestCaseInfo.Result => Result;
@@ -55,5 +61,17 @@ class Xunit3TestCaseInfo : ITestCaseInfo
 		Result = result;
 
 		ResultReported?.Invoke(result);
+	}
+
+	static IReadOnlyDictionary<string, IReadOnlyList<string>> ConvertTraits(IReadOnlyDictionary<string, IReadOnlyCollection<string>>? traits)
+	{
+		if (traits is null || traits.Count == 0)
+			return new Dictionary<string, IReadOnlyList<string>>();
+
+		var result = new Dictionary<string, IReadOnlyList<string>>(traits.Count);
+		foreach (var pair in traits)
+			result[pair.Key] = pair.Value as IReadOnlyList<string> ?? pair.Value.ToList();
+
+		return result;
 	}
 }

--- a/src/DeviceRunners.VisualRunners/Filtering/ITestCaseFilter.cs
+++ b/src/DeviceRunners.VisualRunners/Filtering/ITestCaseFilter.cs
@@ -1,0 +1,12 @@
+namespace DeviceRunners.VisualRunners;
+
+/// <summary>
+/// A parsed test-case filter that can determine whether a given test case matches.
+/// </summary>
+public interface ITestCaseFilter
+{
+	/// <summary>
+	/// Determines whether the given <paramref name="testCase"/> matches the filter.
+	/// </summary>
+	bool Matches(ITestCaseInfo testCase);
+}

--- a/src/DeviceRunners.VisualRunners/Filtering/TestCaseFilter.cs
+++ b/src/DeviceRunners.VisualRunners/Filtering/TestCaseFilter.cs
@@ -1,0 +1,363 @@
+using System.Text;
+
+namespace DeviceRunners.VisualRunners;
+
+/// <summary>
+/// Parses and evaluates a <c>dotnet test --filter</c> style expression against test cases.
+/// </summary>
+/// <remarks>
+/// Supports the documented VSTest filter grammar subset:
+/// <list type="bullet">
+/// <item>Conditions: <c>&lt;property&gt;&lt;operator&gt;&lt;value&gt;</c> with operators
+/// <c>=</c> (equals), <c>!=</c> (not equals), <c>~</c> (contains) and <c>!~</c> (not contains).</item>
+/// <item>Properties (case-insensitive): <c>FullyQualifiedName</c> (the default when the
+/// property is omitted), <c>DisplayName</c>, <c>Name</c>, <c>ClassName</c>, <c>Namespace</c>,
+/// and any trait name (e.g. <c>Category</c>).</item>
+/// <item>Logic: <c>&amp;</c> (and), <c>|</c> (or), grouping with <c>(</c> and <c>)</c>.
+/// <c>&amp;</c> binds tighter than <c>|</c>. Use <c>\</c> to escape a special character.</item>
+/// </list>
+/// </remarks>
+public static class TestCaseFilter
+{
+	/// <summary>
+	/// Parses the given filter expression into an evaluable <see cref="ITestCaseFilter"/>.
+	/// An empty or whitespace expression returns a filter that matches everything.
+	/// </summary>
+	/// <exception cref="FormatException">The expression is malformed.</exception>
+	public static ITestCaseFilter Parse(string? expression)
+	{
+		if (string.IsNullOrWhiteSpace(expression))
+			return MatchAllFilter.Instance;
+
+		var tokens = Tokenize(expression!);
+		var parser = new Parser(tokens, expression!);
+		var filter = parser.Parse();
+		return filter;
+	}
+
+	/// <summary>
+	/// Attempts to parse the given filter expression. Returns <c>false</c> if it is malformed.
+	/// </summary>
+	public static bool TryParse(string? expression, out ITestCaseFilter filter)
+	{
+		try
+		{
+			filter = Parse(expression);
+			return true;
+		}
+		catch (FormatException)
+		{
+			filter = MatchAllFilter.Instance;
+			return false;
+		}
+	}
+
+	enum FilterOperator
+	{
+		Equals,
+		NotEquals,
+		Contains,
+		NotContains,
+	}
+
+	enum TokenKind
+	{
+		Condition,
+		And,
+		Or,
+		OpenParen,
+		CloseParen,
+	}
+
+	readonly struct Token
+	{
+		public Token(TokenKind kind, string property = "", FilterOperator op = FilterOperator.Contains, string value = "")
+		{
+			Kind = kind;
+			Property = property;
+			Operator = op;
+			Value = value;
+		}
+
+		public TokenKind Kind { get; }
+		public string Property { get; }
+		public FilterOperator Operator { get; }
+		public string Value { get; }
+	}
+
+	static List<Token> Tokenize(string expression)
+	{
+		var tokens = new List<Token>();
+		var i = 0;
+
+		while (i < expression.Length)
+		{
+			var c = expression[i];
+
+			switch (c)
+			{
+				case '(':
+					tokens.Add(new Token(TokenKind.OpenParen));
+					i++;
+					break;
+				case ')':
+					tokens.Add(new Token(TokenKind.CloseParen));
+					i++;
+					break;
+				case '&':
+					tokens.Add(new Token(TokenKind.And));
+					i++;
+					break;
+				case '|':
+					tokens.Add(new Token(TokenKind.Or));
+					i++;
+					break;
+				default:
+					i = ReadCondition(expression, i, tokens);
+					break;
+			}
+		}
+
+		return tokens;
+	}
+
+	static int ReadCondition(string expression, int start, List<Token> tokens)
+	{
+		var property = new StringBuilder();
+		var value = new StringBuilder();
+		FilterOperator? op = null;
+		var target = property;
+
+		var i = start;
+		while (i < expression.Length)
+		{
+			var c = expression[i];
+
+			if (c == '\\')
+			{
+				if (i + 1 < expression.Length)
+				{
+					target.Append(expression[i + 1]);
+					i += 2;
+				}
+				else
+				{
+					target.Append('\\');
+					i++;
+				}
+
+				continue;
+			}
+
+			if (c is '(' or ')' or '&' or '|')
+				break;
+
+			if (op is null)
+			{
+				if (c == '=')
+				{
+					op = FilterOperator.Equals;
+					target = value;
+					i++;
+					continue;
+				}
+
+				if (c == '~')
+				{
+					op = FilterOperator.Contains;
+					target = value;
+					i++;
+					continue;
+				}
+
+				if (c == '!' && i + 1 < expression.Length && (expression[i + 1] == '=' || expression[i + 1] == '~'))
+				{
+					op = expression[i + 1] == '=' ? FilterOperator.NotEquals : FilterOperator.NotContains;
+					target = value;
+					i += 2;
+					continue;
+				}
+			}
+
+			target.Append(c);
+			i++;
+		}
+
+		if (op is null)
+		{
+			// A bare value with no operator matches FullyQualifiedName using "contains".
+			var bareValue = property.ToString().Trim();
+			if (bareValue.Length > 0)
+				tokens.Add(new Token(TokenKind.Condition, string.Empty, FilterOperator.Contains, bareValue));
+		}
+		else
+		{
+			tokens.Add(new Token(TokenKind.Condition, property.ToString().Trim(), op.Value, value.ToString().Trim()));
+		}
+
+		return i;
+	}
+
+	sealed class Parser
+	{
+		readonly List<Token> _tokens;
+		readonly string _expression;
+		int _position;
+
+		public Parser(List<Token> tokens, string expression)
+		{
+			_tokens = tokens;
+			_expression = expression;
+		}
+
+		public ITestCaseFilter Parse()
+		{
+			if (_tokens.Count == 0)
+				return MatchAllFilter.Instance;
+
+			var filter = ParseOr();
+
+			if (_position != _tokens.Count)
+				throw Error("unexpected trailing input");
+
+			return filter;
+		}
+
+		ITestCaseFilter ParseOr()
+		{
+			var left = ParseAnd();
+
+			while (Peek()?.Kind == TokenKind.Or)
+			{
+				_position++;
+				var right = ParseAnd();
+				left = new OrFilter(left, right);
+			}
+
+			return left;
+		}
+
+		ITestCaseFilter ParseAnd()
+		{
+			var left = ParsePrimary();
+
+			while (Peek()?.Kind == TokenKind.And)
+			{
+				_position++;
+				var right = ParsePrimary();
+				left = new AndFilter(left, right);
+			}
+
+			return left;
+		}
+
+		ITestCaseFilter ParsePrimary()
+		{
+			var token = Peek() ?? throw Error("unexpected end of expression");
+
+			switch (token.Kind)
+			{
+				case TokenKind.OpenParen:
+					_position++;
+					var inner = ParseOr();
+					if (Peek()?.Kind != TokenKind.CloseParen)
+						throw Error("missing closing parenthesis");
+					_position++;
+					return inner;
+
+				case TokenKind.Condition:
+					_position++;
+					return new ConditionFilter(token.Property, token.Operator, token.Value);
+
+				default:
+					throw Error($"unexpected token '{token.Kind}'");
+			}
+		}
+
+		Token? Peek() =>
+			_position < _tokens.Count ? _tokens[_position] : null;
+
+		FormatException Error(string reason) =>
+			new($"Invalid test filter expression '{_expression}': {reason}.");
+	}
+
+	sealed class MatchAllFilter : ITestCaseFilter
+	{
+		public static readonly MatchAllFilter Instance = new();
+
+		public bool Matches(ITestCaseInfo testCase) => true;
+	}
+
+	sealed class AndFilter(ITestCaseFilter left, ITestCaseFilter right) : ITestCaseFilter
+	{
+		public bool Matches(ITestCaseInfo testCase) =>
+			left.Matches(testCase) && right.Matches(testCase);
+	}
+
+	sealed class OrFilter(ITestCaseFilter left, ITestCaseFilter right) : ITestCaseFilter
+	{
+		public bool Matches(ITestCaseInfo testCase) =>
+			left.Matches(testCase) || right.Matches(testCase);
+	}
+
+	sealed class ConditionFilter(string property, FilterOperator op, string value) : ITestCaseFilter
+	{
+		public bool Matches(ITestCaseInfo testCase)
+		{
+			var actualValues = ResolveValues(testCase);
+
+			return op switch
+			{
+				FilterOperator.Equals => actualValues.Any(Equals),
+				FilterOperator.Contains => actualValues.Any(Contains),
+				FilterOperator.NotEquals => !actualValues.Any(Equals),
+				FilterOperator.NotContains => !actualValues.Any(Contains),
+				_ => false,
+			};
+		}
+
+		bool Equals(string? actual) =>
+			actual is not null && string.Equals(actual, value, StringComparison.OrdinalIgnoreCase);
+
+		bool Contains(string? actual) =>
+			actual is not null && actual.Contains(value, StringComparison.OrdinalIgnoreCase);
+
+		IEnumerable<string?> ResolveValues(ITestCaseInfo testCase)
+		{
+			if (property.Length == 0 || string.Equals(property, "FullyQualifiedName", StringComparison.OrdinalIgnoreCase))
+				return new[] { GetFullyQualifiedName(testCase) };
+
+			if (string.Equals(property, "DisplayName", StringComparison.OrdinalIgnoreCase))
+				return new[] { testCase.DisplayName };
+
+			if (string.Equals(property, "Name", StringComparison.OrdinalIgnoreCase))
+				return new[] { testCase.TestMethodName };
+
+			if (string.Equals(property, "ClassName", StringComparison.OrdinalIgnoreCase))
+				return new[] { testCase.TestClassName };
+
+			if (string.Equals(property, "Namespace", StringComparison.OrdinalIgnoreCase))
+				return new[] { testCase.TestClassNamespace };
+
+			// Otherwise treat the property as a trait name (case-insensitive lookup).
+			foreach (var trait in testCase.Traits)
+			{
+				if (string.Equals(trait.Key, property, StringComparison.OrdinalIgnoreCase))
+					return trait.Value;
+			}
+
+			return Array.Empty<string?>();
+		}
+
+		static string? GetFullyQualifiedName(ITestCaseInfo testCase)
+		{
+			var className = testCase.TestClassName;
+			var methodName = testCase.TestMethodName;
+
+			if (!string.IsNullOrEmpty(className) && !string.IsNullOrEmpty(methodName))
+				return $"{className}.{methodName}";
+
+			return className ?? methodName ?? testCase.DisplayName;
+		}
+	}
+}

--- a/src/DeviceRunners.VisualRunners/IVisualTestRunnerConfiguration.cs
+++ b/src/DeviceRunners.VisualRunners/IVisualTestRunnerConfiguration.cs
@@ -12,4 +12,10 @@ public interface IVisualTestRunnerConfiguration
 	bool AutoStart { get; }
 
 	bool AutoTerminate { get; }
+
+	/// <summary>
+	/// An optional <c>dotnet test --filter</c> style expression. When set, an auto-started
+	/// run executes only the matching test cases instead of the entire suite.
+	/// </summary>
+	string? TestCaseFilter { get; }
 }

--- a/src/DeviceRunners.VisualRunners/IVisualTestRunnerConfigurationBuilder.cs
+++ b/src/DeviceRunners.VisualRunners/IVisualTestRunnerConfigurationBuilder.cs
@@ -12,6 +12,12 @@ public interface IVisualTestRunnerConfigurationBuilder
 
 	void EnableAutoStart(bool autoTerminate = false);
 
+	/// <summary>
+	/// Sets a <c>dotnet test --filter</c> style expression used to select which tests run
+	/// during an auto-started run.
+	/// </summary>
+	void SetTestCaseFilter(string? filter);
+
 	void AddResultChannel<T>(Func<IServiceProvider, T> creator)
 		where T : class, IResultChannel;
 

--- a/src/DeviceRunners.VisualRunners/ViewModels/HomeViewModel.cs
+++ b/src/DeviceRunners.VisualRunners/ViewModels/HomeViewModel.cs
@@ -112,17 +112,28 @@ public class HomeViewModel : AbstractBaseViewModel
 
 		if (_options.AutoStart)
 		{
-			if (string.IsNullOrWhiteSpace(_options.TestCaseFilter))
+			try
 			{
-				_diagnosticsManager?.PostDiagnosticMessage("Auto-starting test run...");
+				if (string.IsNullOrWhiteSpace(_options.TestCaseFilter))
+				{
+					_diagnosticsManager?.PostDiagnosticMessage("Auto-starting test run...");
 
-				await RunEverythingAsync();
+					await RunEverythingAsync();
+				}
+				else
+				{
+					_diagnosticsManager?.PostDiagnosticMessage($"Auto-starting filtered test run ({_options.TestCaseFilter})...");
+
+					await RunFilteredAsync(_options.TestCaseFilter!);
+				}
 			}
-			else
+			catch (Exception ex)
 			{
-				_diagnosticsManager?.PostDiagnosticMessage($"Auto-starting filtered test run ({_options.TestCaseFilter})...");
-
-				await RunFilteredAsync(_options.TestCaseFilter!);
+				// An invalid filter (or any other failure) aborts the run without
+				// opening the result channel. We still need to auto-terminate so the
+				// host process doesn't hang; the missing run is reported as a failure
+				// by the CLI (no "begin" event was received).
+				_diagnosticsManager?.PostDiagnosticMessage($"Test run aborted: {ex.Message}");
 			}
 
 			if (_options.AutoTerminate)
@@ -142,9 +153,8 @@ public class HomeViewModel : AbstractBaseViewModel
 		{
 			if (!TestCaseFilter.TryParse(expression, out var filter))
 			{
-				_diagnosticsManager?.PostDiagnosticMessage($"Invalid test filter expression: '{expression}'. Running everything instead.");
-				await _runner.RunTestsAsync(TestAssemblies.Select(t => t.TestAssemblyInfo).ToList());
-				return;
+				_diagnosticsManager?.PostDiagnosticMessage($"Invalid test filter expression: '{expression}'. Aborting test run.");
+				throw new ArgumentException($"Invalid test filter expression: '{expression}'.", nameof(expression));
 			}
 
 			var matchingCases = TestAssemblies
@@ -154,9 +164,11 @@ public class HomeViewModel : AbstractBaseViewModel
 
 			_diagnosticsManager?.PostDiagnosticMessage($"Filter matched {matchingCases.Count} test case(s).");
 
-			if (matchingCases.Count == 0)
-				return;
-
+			// A filter that matches zero tests is still a successful, empty run
+			// (mirroring `dotnet test --filter`, which exits 0 with "No test matches
+			// the given testcase filter"). Running with an empty set still opens and
+			// closes the result channel, emitting begin/end events so the CLI can
+			// distinguish a clean empty run from a crash or missing connection.
 			await _runner.RunTestsAsync(matchingCases);
 		}
 		finally

--- a/src/DeviceRunners.VisualRunners/ViewModels/HomeViewModel.cs
+++ b/src/DeviceRunners.VisualRunners/ViewModels/HomeViewModel.cs
@@ -112,9 +112,18 @@ public class HomeViewModel : AbstractBaseViewModel
 
 		if (_options.AutoStart)
 		{
-			_diagnosticsManager?.PostDiagnosticMessage("Auto-starting test run...");
+			if (string.IsNullOrWhiteSpace(_options.TestCaseFilter))
+			{
+				_diagnosticsManager?.PostDiagnosticMessage("Auto-starting test run...");
 
-			await RunEverythingAsync();
+				await RunEverythingAsync();
+			}
+			else
+			{
+				_diagnosticsManager?.PostDiagnosticMessage($"Auto-starting filtered test run ({_options.TestCaseFilter})...");
+
+				await RunFilteredAsync(_options.TestCaseFilter!);
+			}
 
 			if (_options.AutoTerminate)
 			{
@@ -122,6 +131,38 @@ public class HomeViewModel : AbstractBaseViewModel
 
 				_appTerminator?.Terminate();
 			}
+		}
+	}
+
+	async Task RunFilteredAsync(string expression)
+	{
+		IsBusy = true;
+
+		try
+		{
+			if (!TestCaseFilter.TryParse(expression, out var filter))
+			{
+				_diagnosticsManager?.PostDiagnosticMessage($"Invalid test filter expression: '{expression}'. Running everything instead.");
+				await _runner.RunTestsAsync(TestAssemblies.Select(t => t.TestAssemblyInfo).ToList());
+				return;
+			}
+
+			var matchingCases = TestAssemblies
+				.SelectMany(t => t.TestAssemblyInfo.TestCases)
+				.Where(filter.Matches)
+				.ToList();
+
+			_diagnosticsManager?.PostDiagnosticMessage($"Filter matched {matchingCases.Count} test case(s).");
+
+			if (matchingCases.Count == 0)
+				return;
+
+			await _runner.RunTestsAsync(matchingCases);
+		}
+		finally
+		{
+			_diagnosticsManager?.PostDiagnosticMessage("Test run complete.");
+			IsBusy = false;
 		}
 	}
 

--- a/src/DeviceRunners.VisualRunners/VisualTestRunnerConfiguration.cs
+++ b/src/DeviceRunners.VisualRunners/VisualTestRunnerConfiguration.cs
@@ -7,11 +7,13 @@ public class VisualTestRunnerConfiguration : IVisualTestRunnerConfiguration
 	public VisualTestRunnerConfiguration(
 		IReadOnlyList<Assembly> testAssemblies,
 		bool autoStart = false,
-		bool autoTerminate = false)
+		bool autoTerminate = false,
+		string? testCaseFilter = null)
 	{
 		TestAssemblies = testAssemblies?.ToList() ?? throw new ArgumentNullException(nameof(testAssemblies));
 		AutoStart = autoStart;
 		AutoTerminate = autoTerminate;
+		TestCaseFilter = testCaseFilter;
 	}
 
 	public IReadOnlyList<Assembly> TestAssemblies { get; }
@@ -19,4 +21,6 @@ public class VisualTestRunnerConfiguration : IVisualTestRunnerConfiguration
 	public bool AutoStart { get; }
 
 	public bool AutoTerminate { get; }
+
+	public string? TestCaseFilter { get; }
 }

--- a/src/DeviceRunners.VisualRunners/VisualTestRunnerConfigurationBuilderExtensions.cs
+++ b/src/DeviceRunners.VisualRunners/VisualTestRunnerConfigurationBuilderExtensions.cs
@@ -37,6 +37,13 @@ public static class VisualTestRunnerConfigurationBuilderExtensions
 		return builder;
 	}
 
+	public static TBuilder SetTestCaseFilter<TBuilder>(this TBuilder builder, string? filter)
+		where TBuilder : IVisualTestRunnerConfigurationBuilder
+	{
+		builder.SetTestCaseFilter(filter);
+		return builder;
+	}
+
 	public static TBuilder AddConsoleResultChannel<TBuilder>(this TBuilder builder)
 		where TBuilder : IVisualTestRunnerConfigurationBuilder
 	{

--- a/test/DeviceRunners.Cli.Tests/Commands/AppEnvironmentVariableTests.cs
+++ b/test/DeviceRunners.Cli.Tests/Commands/AppEnvironmentVariableTests.cs
@@ -1,0 +1,48 @@
+using DeviceRunners.Cli.Commands;
+
+namespace DeviceRunners.Cli.Tests;
+
+public class AppEnvironmentVariableTests
+{
+	[Fact]
+	public void Filter_WhenSet_IsAddedToEnvironment()
+	{
+		var settings = new WindowsTestCommand.Settings
+		{
+			App = "app.msix",
+			Filter = "FullyQualifiedName~MyClass",
+		};
+
+		var env = BaseTestCommand<WindowsTestCommand.Settings>.GetAppEnvironmentVariables(settings);
+
+		Assert.Equal("FullyQualifiedName~MyClass", env["DEVICE_RUNNERS_FILTER"]);
+		Assert.Equal("1", env["DEVICE_RUNNERS_AUTORUN"]);
+	}
+
+	[Fact]
+	public void Filter_WhenNotSet_IsOmittedFromEnvironment()
+	{
+		var settings = new WindowsTestCommand.Settings
+		{
+			App = "app.msix",
+		};
+
+		var env = BaseTestCommand<WindowsTestCommand.Settings>.GetAppEnvironmentVariables(settings);
+
+		Assert.False(env.ContainsKey("DEVICE_RUNNERS_FILTER"));
+	}
+
+	[Fact]
+	public void Filter_WhenWhitespace_IsOmittedFromEnvironment()
+	{
+		var settings = new WindowsTestCommand.Settings
+		{
+			App = "app.msix",
+			Filter = "   ",
+		};
+
+		var env = BaseTestCommand<WindowsTestCommand.Settings>.GetAppEnvironmentVariables(settings);
+
+		Assert.False(env.ContainsKey("DEVICE_RUNNERS_FILTER"));
+	}
+}

--- a/test/DeviceRunners.Cli.Tests/Commands/ClassifyRunTests.cs
+++ b/test/DeviceRunners.Cli.Tests/Commands/ClassifyRunTests.cs
@@ -1,0 +1,46 @@
+using DeviceRunners.Cli.Commands;
+
+using Xunit;
+
+using TestRunOutcome = DeviceRunners.Cli.Commands.BaseTestCommand<DeviceRunners.Cli.Commands.WindowsTestCommand.Settings>.TestRunOutcome;
+
+namespace DeviceRunners.Cli.Tests;
+
+public class ClassifyRunTests
+{
+	static TestRunOutcome Classify(bool hasStarted, bool hasEnded, int totalCount) =>
+		BaseTestCommand<WindowsTestCommand.Settings>.ClassifyRun(hasStarted, hasEnded, totalCount);
+
+	[Fact]
+	public void NormalRunIsCompleted()
+	{
+		Assert.Equal(TestRunOutcome.Completed, Classify(hasStarted: true, hasEnded: true, totalCount: 5));
+	}
+
+	[Fact]
+	public void ZeroMatchFilterIsCleanEmpty()
+	{
+		// begin + end received, but no results: a successful empty run.
+		Assert.Equal(TestRunOutcome.CleanEmpty, Classify(hasStarted: true, hasEnded: true, totalCount: 0));
+	}
+
+	[Fact]
+	public void BeginWithResultsButNoEndIsCrash()
+	{
+		Assert.Equal(TestRunOutcome.Crashed, Classify(hasStarted: true, hasEnded: false, totalCount: 3));
+	}
+
+	[Fact]
+	public void NoConnectionIsNoResults()
+	{
+		Assert.Equal(TestRunOutcome.NoResults, Classify(hasStarted: false, hasEnded: false, totalCount: 0));
+	}
+
+	[Fact]
+	public void BeginWithoutEndAndNoResultsIsNoResults()
+	{
+		// App connected and sent begin but never produced results or an end event
+		// (e.g. it died immediately). Not a clean empty run, so it's a failure.
+		Assert.Equal(TestRunOutcome.NoResults, Classify(hasStarted: true, hasEnded: false, totalCount: 0));
+	}
+}

--- a/test/DeviceRunners.Cli.Tests/Commands/ClassifyRunTests.cs
+++ b/test/DeviceRunners.Cli.Tests/Commands/ClassifyRunTests.cs
@@ -43,4 +43,44 @@ public class ClassifyRunTests
 		// (e.g. it died immediately). Not a clean empty run, so it's a failure.
 		Assert.Equal(TestRunOutcome.NoResults, Classify(hasStarted: true, hasEnded: false, totalCount: 0));
 	}
+
+	static bool IsSuccess(TestRunOutcome outcome, int failedCount) =>
+		BaseTestCommand<WindowsTestCommand.Settings>.OutcomeIsSuccess(outcome, failedCount);
+
+	static int ExitCode(TestRunOutcome outcome, int failedCount) =>
+		BaseTestCommand<WindowsTestCommand.Settings>.OutcomeToExitCode(outcome, failedCount);
+
+	[Fact]
+	public void CompletedRunSucceedsOnlyWithNoFailures()
+	{
+		Assert.True(IsSuccess(TestRunOutcome.Completed, failedCount: 0));
+		Assert.Equal(0, ExitCode(TestRunOutcome.Completed, failedCount: 0));
+
+		Assert.False(IsSuccess(TestRunOutcome.Completed, failedCount: 2));
+		Assert.Equal(1, ExitCode(TestRunOutcome.Completed, failedCount: 2));
+	}
+
+	[Fact]
+	public void CleanEmptyRunSucceeds()
+	{
+		Assert.True(IsSuccess(TestRunOutcome.CleanEmpty, failedCount: 0));
+		Assert.Equal(0, ExitCode(TestRunOutcome.CleanEmpty, failedCount: 0));
+	}
+
+	[Fact]
+	public void CrashIsNeverSuccessEvenWithNoRecordedFailures()
+	{
+		// Regression guard: a crash/timeout mid-run (begin + partial results, no end)
+		// must not be reported as a successful, passing run just because none of the
+		// results that did arrive were failures.
+		Assert.False(IsSuccess(TestRunOutcome.Crashed, failedCount: 0));
+		Assert.Equal(2, ExitCode(TestRunOutcome.Crashed, failedCount: 0));
+	}
+
+	[Fact]
+	public void NoResultsIsFailure()
+	{
+		Assert.False(IsSuccess(TestRunOutcome.NoResults, failedCount: 0));
+		Assert.Equal(1, ExitCode(TestRunOutcome.NoResults, failedCount: 0));
+	}
 }

--- a/test/DeviceRunners.Cli.Tests/Services/EventStreamServiceTests.cs
+++ b/test/DeviceRunners.Cli.Tests/Services/EventStreamServiceTests.cs
@@ -203,6 +203,11 @@ public class EventStreamServiceTests
         public ITestAssemblyInfo TestAssembly { get; } = new StubTestAssemblyInfo();
         public string DisplayName { get; } = displayName;
         public ITestResultInfo? Result => null;
+        public string? TestClassName => null;
+        public string? TestMethodName => null;
+        public string? TestClassNamespace => null;
+        public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; } =
+            new Dictionary<string, IReadOnlyList<string>>();
         public event Action<ITestResultInfo>? ResultReported { add { } remove { } }
     }
 

--- a/test/DeviceRunners.VisualRunners.Tests/Testing/HomeViewModelTests.NUnit.cs
+++ b/test/DeviceRunners.VisualRunners.Tests/Testing/HomeViewModelTests.NUnit.cs
@@ -11,4 +11,6 @@ public class NUnitHomeViewModelTests : HomeViewModelTests
 
 	public override ITestRunner CreateTestRunner(VisualTestRunnerConfiguration configuration) =>
 		new NUnitTestRunner(configuration);
+
+	public override string SingleClassName => "TestProject.Tests.NUnitTests";
 }

--- a/test/DeviceRunners.VisualRunners.Tests/Testing/HomeViewModelTests.cs
+++ b/test/DeviceRunners.VisualRunners.Tests/Testing/HomeViewModelTests.cs
@@ -117,4 +117,52 @@ public abstract class HomeViewModelTests
 		else
 			terminator.DidNotReceive().Terminate();
 	}
+
+	[Fact]
+	public async Task AutoStartWithZeroMatchFilterCompletesWithoutRunningTests()
+	{
+		var assemblies = new[] { TestAssembly };
+		var filter = "FullyQualifiedName=Does.Not.Exist.AtAll";
+		var options = new VisualTestRunnerConfiguration(assemblies, autoStart: true, autoTerminate: true, testCaseFilter: filter);
+		var discoverer = CreateTestDiscoverer(options);
+		var runner = CreateTestRunner(options);
+		var channels = new DefaultResultChannelManager();
+
+		var terminator = Substitute.For<IAppTerminator>();
+
+		var vm = new HomeViewModel(options, [discoverer], [runner], channels, terminator);
+
+		await vm.StartAssemblyScanAsync();
+
+		// A zero-match filter is a successful empty run: no test executes,
+		// but the runner still completes and auto-terminate fires.
+		var allCases = vm.TestAssemblies.SelectMany(a => a.TestCases).ToList();
+		Assert.All(allCases, c => Assert.Equal(TestResultStatus.NotRun, c.ResultStatus));
+
+		terminator.Received().Terminate();
+	}
+
+	[Fact]
+	public async Task AutoStartWithInvalidFilterAbortsButStillTerminates()
+	{
+		var assemblies = new[] { TestAssembly };
+		var filter = "(FullyQualifiedName=Adds";
+		var options = new VisualTestRunnerConfiguration(assemblies, autoStart: true, autoTerminate: true, testCaseFilter: filter);
+		var discoverer = CreateTestDiscoverer(options);
+		var runner = CreateTestRunner(options);
+		var channels = new DefaultResultChannelManager();
+
+		var terminator = Substitute.For<IAppTerminator>();
+
+		var vm = new HomeViewModel(options, [discoverer], [runner], channels, terminator);
+
+		await vm.StartAssemblyScanAsync();
+
+		// An invalid filter aborts the run (no test executes), but the app must
+		// still auto-terminate so the host process does not hang.
+		var allCases = vm.TestAssemblies.SelectMany(a => a.TestCases).ToList();
+		Assert.All(allCases, c => Assert.Equal(TestResultStatus.NotRun, c.ResultStatus));
+
+		terminator.Received().Terminate();
+	}
 }

--- a/test/DeviceRunners.VisualRunners.Tests/Testing/HomeViewModelTests.cs
+++ b/test/DeviceRunners.VisualRunners.Tests/Testing/HomeViewModelTests.cs
@@ -21,6 +21,55 @@ public abstract class HomeViewModelTests
 
 	public virtual int ExpectedTestCount => Constants.TestCount;
 
+	public virtual string SingleClassName => "TestProject.Tests.XunitTests";
+
+	[Fact]
+	public async Task DiscoveredTestCasesExposeClassAndMethodMetadata()
+	{
+		var assemblies = new[] { TestAssembly };
+		var options = new VisualTestRunnerConfiguration(assemblies);
+		var discoverer = CreateTestDiscoverer(options);
+		var runner = CreateTestRunner(options);
+		var channels = new DefaultResultChannelManager();
+
+		var vm = new HomeViewModel(options, [discoverer], [runner], channels);
+		await vm.StartAssemblyScanAsync();
+
+		var cases = vm.TestAssemblies
+			.SelectMany(a => a.TestAssemblyInfo.TestCases)
+			.ToList();
+
+		var simpleTest = Assert.Single(
+			cases,
+			c => c.TestClassName == SingleClassName && c.TestMethodName == "SimpleTest");
+
+		Assert.Equal(SingleClassName, simpleTest.TestClassName);
+		Assert.Equal("SimpleTest", simpleTest.TestMethodName);
+		Assert.Equal("TestProject.Tests", simpleTest.TestClassNamespace);
+	}
+
+	[Fact]
+	public async Task AutoStartWithFilterRunsOnlyMatchingTests()
+	{
+		var assemblies = new[] { TestAssembly };
+		var filter = $"FullyQualifiedName={SingleClassName}.SimpleTest";
+		var options = new VisualTestRunnerConfiguration(assemblies, autoStart: true, testCaseFilter: filter);
+		var discoverer = CreateTestDiscoverer(options);
+		var runner = CreateTestRunner(options);
+		var channels = new DefaultResultChannelManager();
+
+		var vm = new HomeViewModel(options, [discoverer], [runner], channels);
+		await vm.StartAssemblyScanAsync();
+
+		var allCases = vm.TestAssemblies.SelectMany(a => a.TestCases).ToList();
+
+		var ran = allCases.Where(c => c.ResultStatus != TestResultStatus.NotRun).ToList();
+		Assert.All(ran, c => Assert.Contains("SimpleTest", c.TestCaseInfo.TestMethodName));
+
+		var dataTest = allCases.Where(c => c.TestCaseInfo.TestMethodName == "DataTest");
+		Assert.All(dataTest, c => Assert.Equal(TestResultStatus.NotRun, c.ResultStatus));
+	}
+
 	[Fact]
 	public async Task StartAssemblyScanAsyncCreatesAllTheViewExpectedModels()
 	{

--- a/test/DeviceRunners.VisualRunners.Tests/Testing/TestCaseFilterTests.cs
+++ b/test/DeviceRunners.VisualRunners.Tests/Testing/TestCaseFilterTests.cs
@@ -1,0 +1,154 @@
+using DeviceRunners.VisualRunners;
+
+using Xunit;
+
+namespace VisualRunnerTests.Testing;
+
+public class TestCaseFilterTests
+{
+	static StubTestCaseInfo Case(
+		string? className = "MyApp.Calculator",
+		string? methodName = "Adds",
+		string? displayName = null,
+		params (string Key, string[] Values)[] traits)
+	{
+		var traitDict = new Dictionary<string, IReadOnlyList<string>>();
+		foreach (var (key, values) in traits)
+			traitDict[key] = values;
+
+		return new StubTestCaseInfo
+		{
+			TestClassName = className,
+			TestMethodName = methodName,
+			DisplayName = displayName ?? $"{className}.{methodName}",
+			Traits = traitDict,
+		};
+	}
+
+	[Theory]
+	[InlineData("FullyQualifiedName=MyApp.Calculator.Adds", true)]
+	[InlineData("FullyQualifiedName=MyApp.Calculator.Subtracts", false)]
+	[InlineData("FullyQualifiedName~Calculator", true)]
+	[InlineData("FullyQualifiedName~Other", false)]
+	[InlineData("FullyQualifiedName!=MyApp.Calculator.Adds", false)]
+	[InlineData("FullyQualifiedName!~Other", true)]
+	public void FullyQualifiedNameMatching(string expression, bool expected)
+	{
+		var filter = TestCaseFilter.Parse(expression);
+		Assert.Equal(expected, filter.Matches(Case()));
+	}
+
+	[Fact]
+	public void BareValueMatchesFullyQualifiedNameContains()
+	{
+		var filter = TestCaseFilter.Parse("Calculator");
+		Assert.True(filter.Matches(Case()));
+		Assert.False(filter.Matches(Case(className: "MyApp.Other")));
+	}
+
+	[Fact]
+	public void NameMatchesMethodSimpleName()
+	{
+		var filter = TestCaseFilter.Parse("Name=Adds");
+		Assert.True(filter.Matches(Case()));
+		Assert.False(filter.Matches(Case(methodName: "Subtracts")));
+	}
+
+	[Fact]
+	public void ClassNameAndNamespaceMatching()
+	{
+		var caseInfo = Case();
+		Assert.True(TestCaseFilter.Parse("ClassName=MyApp.Calculator").Matches(caseInfo));
+		Assert.True(TestCaseFilter.Parse("Namespace=MyApp").Matches(caseInfo));
+		Assert.False(TestCaseFilter.Parse("Namespace=Other").Matches(caseInfo));
+	}
+
+	[Fact]
+	public void DisplayNameMatching()
+	{
+		var caseInfo = Case(displayName: "Calculator adds two numbers");
+		Assert.True(TestCaseFilter.Parse("DisplayName~two numbers").Matches(caseInfo));
+	}
+
+	[Fact]
+	public void TraitMatching()
+	{
+		var caseInfo = Case(traits: ("Category", new[] { "Smoke", "Fast" }));
+		Assert.True(TestCaseFilter.Parse("Category=Smoke").Matches(caseInfo));
+		Assert.True(TestCaseFilter.Parse("Category=Fast").Matches(caseInfo));
+		Assert.False(TestCaseFilter.Parse("Category=Slow").Matches(caseInfo));
+		Assert.True(TestCaseFilter.Parse("category~Sm").Matches(caseInfo));
+	}
+
+	[Fact]
+	public void AndBindsTighterThanOr()
+	{
+		// Adds & Category=Slow | Subtracts  =>  (Adds & Slow) | Subtracts
+		var filter = TestCaseFilter.Parse("Name=Adds&Category=Slow|Name=Subtracts");
+
+		Assert.False(filter.Matches(Case(methodName: "Adds", traits: ("Category", new[] { "Fast" }))));
+		Assert.True(filter.Matches(Case(methodName: "Adds", traits: ("Category", new[] { "Slow" }))));
+		Assert.True(filter.Matches(Case(methodName: "Subtracts")));
+	}
+
+	[Fact]
+	public void ParenthesesOverridePrecedence()
+	{
+		var filter = TestCaseFilter.Parse("(Name=Adds|Name=Subtracts)&Category=Smoke");
+
+		Assert.True(filter.Matches(Case(methodName: "Adds", traits: ("Category", new[] { "Smoke" }))));
+		Assert.False(filter.Matches(Case(methodName: "Adds", traits: ("Category", new[] { "Other" }))));
+		Assert.False(filter.Matches(Case(methodName: "Multiplies", traits: ("Category", new[] { "Smoke" }))));
+	}
+
+	[Fact]
+	public void EscapedSpecialCharacters()
+	{
+		var caseInfo = Case(className: "MyApp.Calc(v2)", methodName: "Adds");
+		var filter = TestCaseFilter.Parse(@"FullyQualifiedName~Calc\(v2\)");
+		Assert.True(filter.Matches(caseInfo));
+	}
+
+	[Fact]
+	public void EmptyOrNullExpressionMatchesEverything()
+	{
+		Assert.True(TestCaseFilter.Parse(null).Matches(Case()));
+		Assert.True(TestCaseFilter.Parse("").Matches(Case()));
+		Assert.True(TestCaseFilter.Parse("   ").Matches(Case()));
+	}
+
+	[Theory]
+	[InlineData("(Name=Adds")]
+	[InlineData("Name=Adds)")]
+	[InlineData("Name=Adds&")]
+	[InlineData("|Name=Adds")]
+	public void MalformedExpressionsThrow(string expression)
+	{
+		Assert.Throws<FormatException>(() => TestCaseFilter.Parse(expression));
+	}
+
+	[Fact]
+	public void TryParseReturnsFalseOnMalformed()
+	{
+		Assert.False(TestCaseFilter.TryParse("(Name=Adds", out _));
+		Assert.True(TestCaseFilter.TryParse("Name=Adds", out var filter));
+		Assert.True(filter.Matches(Case()));
+	}
+
+	class StubTestCaseInfo : ITestCaseInfo
+	{
+		public ITestAssemblyInfo TestAssembly { get; set; } = null!;
+		public string DisplayName { get; set; } = "";
+		public ITestResultInfo? Result => null;
+		public string? TestClassName { get; set; }
+		public string? TestMethodName { get; set; }
+		public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; set; } =
+			new Dictionary<string, IReadOnlyList<string>>();
+
+		public event Action<ITestResultInfo>? ResultReported
+		{
+			add { }
+			remove { }
+		}
+	}
+}

--- a/test/DeviceRunners.VisualRunners.Tests/Testing/TestCaseFilterTests.cs
+++ b/test/DeviceRunners.VisualRunners.Tests/Testing/TestCaseFilterTests.cs
@@ -142,6 +142,16 @@ public class TestCaseFilterTests
 		public ITestResultInfo? Result => null;
 		public string? TestClassName { get; set; }
 		public string? TestMethodName { get; set; }
+		public string? TestClassNamespace
+		{
+			get
+			{
+				if (string.IsNullOrEmpty(TestClassName))
+					return null;
+				var index = TestClassName!.LastIndexOf('.');
+				return index > 0 ? TestClassName.Substring(0, index) : null;
+			}
+		}
 		public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; set; } =
 			new Dictionary<string, IReadOnlyList<string>>();
 

--- a/test/DeviceRunners.VisualRunners.Tests/ViewModelTesting/FilteredCollectionViewConcurrencyTests.cs
+++ b/test/DeviceRunners.VisualRunners.Tests/ViewModelTesting/FilteredCollectionViewConcurrencyTests.cs
@@ -222,6 +222,11 @@ public class FilteredCollectionViewConcurrencyTests
 		public ITestAssemblyInfo TestAssembly { get; }
 		public string DisplayName { get; }
 		public ITestResultInfo? Result { get; private set; }
+		public string? TestClassName => null;
+		public string? TestMethodName => null;
+		public string? TestClassNamespace => null;
+		public IReadOnlyDictionary<string, IReadOnlyList<string>> Traits { get; } =
+			new Dictionary<string, IReadOnlyList<string>>();
 
 		public event Action<ITestResultInfo>? ResultReported;
 

--- a/test/DeviceRunners.VisualRunners.Xunit3.Tests/Testing/HomeViewModelTests.cs
+++ b/test/DeviceRunners.VisualRunners.Xunit3.Tests/Testing/HomeViewModelTests.cs
@@ -108,4 +108,46 @@ public class Xunit3HomeViewModelTests
 		var dataTest = allCases.Where(c => c.TestCaseInfo.TestMethodName == "DataTest");
 		Assert.All(dataTest, c => Assert.Equal(TestResultStatus.NotRun, c.ResultStatus));
 	}
+
+	[Fact]
+	public async Task AutoStartWithZeroMatchFilterCompletesWithoutRunningTests()
+	{
+		var assemblies = new[] { TestAssembly };
+		var filter = "FullyQualifiedName=Does.Not.Exist.AtAll";
+		var options = new VisualTestRunnerConfiguration(assemblies, autoStart: true, autoTerminate: true, testCaseFilter: filter);
+		var discoverer = new Xunit3TestDiscoverer(options);
+		var runner = new Xunit3TestRunner(options);
+		var channels = new DefaultResultChannelManager();
+
+		var terminator = Substitute.For<IAppTerminator>();
+
+		var vm = new HomeViewModel(options, [discoverer], [runner], channels, terminator);
+		await vm.StartAssemblyScanAsync(TestContext.Current.CancellationToken);
+
+		var allCases = vm.TestAssemblies.SelectMany(a => a.TestCases).ToList();
+		Assert.All(allCases, c => Assert.Equal(TestResultStatus.NotRun, c.ResultStatus));
+
+		terminator.Received().Terminate();
+	}
+
+	[Fact]
+	public async Task AutoStartWithInvalidFilterAbortsButStillTerminates()
+	{
+		var assemblies = new[] { TestAssembly };
+		var filter = "(FullyQualifiedName=Adds";
+		var options = new VisualTestRunnerConfiguration(assemblies, autoStart: true, autoTerminate: true, testCaseFilter: filter);
+		var discoverer = new Xunit3TestDiscoverer(options);
+		var runner = new Xunit3TestRunner(options);
+		var channels = new DefaultResultChannelManager();
+
+		var terminator = Substitute.For<IAppTerminator>();
+
+		var vm = new HomeViewModel(options, [discoverer], [runner], channels, terminator);
+		await vm.StartAssemblyScanAsync(TestContext.Current.CancellationToken);
+
+		var allCases = vm.TestAssemblies.SelectMany(a => a.TestCases).ToList();
+		Assert.All(allCases, c => Assert.Equal(TestResultStatus.NotRun, c.ResultStatus));
+
+		terminator.Received().Terminate();
+	}
 }

--- a/test/DeviceRunners.VisualRunners.Xunit3.Tests/Testing/HomeViewModelTests.cs
+++ b/test/DeviceRunners.VisualRunners.Xunit3.Tests/Testing/HomeViewModelTests.cs
@@ -63,4 +63,49 @@ public class Xunit3HomeViewModelTests
 		else
 			terminator.DidNotReceive().Terminate();
 	}
+
+	[Fact]
+	public async Task DiscoveredTestCasesExposeClassAndMethodMetadata()
+	{
+		var assemblies = new[] { TestAssembly };
+		var options = new VisualTestRunnerConfiguration(assemblies);
+		var discoverer = new Xunit3TestDiscoverer(options);
+		var runner = new Xunit3TestRunner(options);
+		var channels = new DefaultResultChannelManager();
+
+		var vm = new HomeViewModel(options, [discoverer], [runner], channels);
+		await vm.StartAssemblyScanAsync(TestContext.Current.CancellationToken);
+
+		var cases = vm.TestAssemblies
+			.SelectMany(a => a.TestAssemblyInfo.TestCases)
+			.ToList();
+
+		var simpleTest = Assert.Single(
+			cases,
+			c => c.TestClassName == "TestProject.Xunit3Tests.Xunit3Tests" && c.TestMethodName == "SimpleTest");
+
+		Assert.Equal("TestProject.Xunit3Tests", simpleTest.TestClassNamespace);
+	}
+
+	[Fact]
+	public async Task AutoStartWithFilterRunsOnlyMatchingTests()
+	{
+		var assemblies = new[] { TestAssembly };
+		var filter = "FullyQualifiedName=TestProject.Xunit3Tests.Xunit3Tests.SimpleTest";
+		var options = new VisualTestRunnerConfiguration(assemblies, autoStart: true, testCaseFilter: filter);
+		var discoverer = new Xunit3TestDiscoverer(options);
+		var runner = new Xunit3TestRunner(options);
+		var channels = new DefaultResultChannelManager();
+
+		var vm = new HomeViewModel(options, [discoverer], [runner], channels);
+		await vm.StartAssemblyScanAsync(TestContext.Current.CancellationToken);
+
+		var allCases = vm.TestAssemblies.SelectMany(a => a.TestCases).ToList();
+
+		var ran = allCases.Where(c => c.ResultStatus != TestResultStatus.NotRun).ToList();
+		Assert.All(ran, c => Assert.Contains("SimpleTest", c.TestCaseInfo.TestMethodName));
+
+		var dataTest = allCases.Where(c => c.TestCaseInfo.TestMethodName == "DataTest");
+		Assert.All(dataTest, c => Assert.Equal(TestResultStatus.NotRun, c.ResultStatus));
+	}
 }


### PR DESCRIPTION
## Summary

Makes `dotnet test --filter "..."` (and the equivalent CLI / MSBuild plumbing) actually work for DeviceRunners device test runs, then dogfoods that feature to replace the `INCLUDE_FAILING_TESTS` conditional-compilation hack with a category-based filter.

Previously `dotnet test --filter` was silently ignored: the `DeviceRunners.Testing.Targets` package replaces the VSTest target, so the standard filter pipeline never ran and the app always auto-ran the whole suite. There was no way to run a single test or class on-device.

## What changed

### 1. `--filter` support
- A small, self-contained VSTest `--filter` parser/evaluator (`ITestCaseFilter` / `TestCaseFilter.Parse`) over a framework-agnostic `ITestCaseInfo` metadata surface (class / namespace / method / traits). No dependency on `TestPlatform.Common` — AOT/trim/WASM-safe.
- Metadata is populated for all three frameworks: xUnit v2, xUnit v3, NUnit.
- The filter string is plumbed through every channel: MSBuild `$(VSTestTestCaseFilter)` → CLI `--filter` / `DEVICE_RUNNERS_FILTER` env var → Windows MSIX `--device-runners-filter` arg / WASM URL query → MAUI & Blazor config readers → `HomeViewModel` (filters the discovered cases and runs the subset on autostart).
- Supported grammar mirrors the documented `dotnet test --filter` subset: `FullyQualifiedName` (default), `DisplayName`, `Name`, `ClassName`, `Namespace`, and any trait/category; operators `=` `!=` `~` `!~`; `&` `|` and parentheses; `\` escaping.

### 2. Replace `INCLUDE_FAILING_TESTS` with the `ExpectedFailure` category
- The intentionally-failing demo tests are now **always compiled in** and tagged with an `ExpectedFailure` category (`[Trait("Category","ExpectedFailure")]` for xUnit/xUnit v3, `[Category("ExpectedFailure")]` for NUnit) instead of being `#if`-compiled out. They stay visible for local/interactive runs; CI keeps the suite green by **excluding** that category through each runner path:
  - **`dotnet test`** – CI passes `--filter "Category!=ExpectedFailure"` on the command line. The targets deliver it to the app as a runtime filter (env var, or baked Android `__environment__.txt`), so the real filter code path runs on-device. An explicit user `--filter` still wins.
  - **TCP (CLI)** – the workflows publish the app with `-p:IncludeFailingTests=false`, which defines the `EXCLUDE_FAILING_TESTS` compile constant. `MauiProgram` reads it and bakes `SetTestCaseFilter("Category!=ExpectedFailure")` into the runner. (The installed app auto-starts without reliably receiving a runtime filter on every platform — notably Android `am start` — so the exclusion is gated at build time but still applied through the same runtime filter engine.)
  - **WASM (CLI)** – the workflow passes `--filter "Category!=ExpectedFailure"`.
  - WASM run classification was also hardened: a run that starts and emits results but never reaches the "end" event (a crash or timeout mid-run) is now reported as a crash (exit 2) instead of being mis-classified as a pass. WASM now shares the same `ClassifyRun` outcome model as the TCP runners.
  - **XHarness** – same `-p:IncludeFailingTests=false` → `EXCLUDE_FAILING_TESTS` gating as TCP; `MauiProgram` then skips the category in-process via `.SkipCategory("Category", "ExpectedFailure")`. Local XHarness runs (without the property) still show the failure demos.

## Testing
- `dotnet test test/Tests.slnx`: **351 passing** (VisualRunners.Tests 207, Cli.Tests 70, VisualRunners.Xunit3.Tests 74).
  - Parser/evaluator cases (FQN equals/contains/not, bare-value→FQN, `Name`/`ClassName`/`Namespace`/`DisplayName`, traits, `&`/`|` precedence, parentheses, escaping, empty/malformed, `TryParse`), plus per-framework metadata-mapping and autostart-filter integration tests, and `ClassifyRun` outcome/exit-code tests covering the WASM crash-never-success regression.
- **On-device validation (Android emulator, Pixel API 35):** TCP run reports `Total=86, Passed=82, Failed=0, Skipped=4` with the `ExpectedFailure` tests absent from the event stream — confirming the baked runtime filter excludes them in the MAUI program (not via compile-out).
- **CI:** all `dotnet test`, TCP (Android, Windows EXE/Loose/MSIX, iOS, macOS), WASM and XHarness jobs green on both GitHub Actions and Azure DevOps.

## Notes
- The filter only affects the headless `dotnet test` / CLI / TCP-CI runs; launching the app interactively from the IDE still shows the full visual runner, so the failure demos remain visible locally.
- Documented the `--filter` grammar and the `ExpectedFailure` convention in `docs/articles/using-dotnet-test.md`, the per-runner CI exclusion mechanics in `docs/articles/ci-pipeline.md`, and the visual-runner filter support in `docs/articles/xunit-v3-support.md`.