### PR TITLE
Support Microsoft Testing Platform simple test filters + wildcards

### DIFF
--- a/docs/articles/using-devicerunners-cli.md
+++ b/docs/articles/using-devicerunners-cli.md
@@ -84,6 +84,76 @@ device-runners ios test --app path/to/app.app --results-directory results
 device-runners wasm test --app path/to/wwwroot --logger "trx;LogFileName=test-results.trx" --results-directory results
 ```
 
+### Filtering Tests
+
+By default the `test` command runs every test in the app. You can run a subset in two
+mutually-exclusive ways: a single `--filter` expression, or the Microsoft Testing Platform
+"simple" filter switches. The chosen filter is forwarded to the device and evaluated
+on-device, so it works the same across all frameworks (xUnit v2, xUnit v3 and NUnit) and
+platforms.
+
+> [!NOTE]
+> Filtering is delivered to the app at launch time. On **Android** the filter is baked in
+> at build time (via the `dotnet test` MSBuild integration), so the `device-runners android
+> test` command launches an already-installed app and does not re-apply these options — use
+> the `dotnet test --filter` path for Android filtering.
+
+#### `--filter` (VSTest-style expression)
+
+A single `dotnet test --filter` style expression:
+
+```bash
+# A single test
+device-runners windows test --app app.msix \
+  --filter "FullyQualifiedName=MyApp.Tests.CalculatorTests.Adds"
+
+# Everything in a class, using a wildcard
+device-runners windows test --app app.msix \
+  --filter "ClassName=*CalculatorTests"
+```
+
+The supported properties are `FullyQualifiedName` (default), `DisplayName`, `Name`,
+`ClassName`, `Namespace` and any trait name. Operators are `=`, `!=`, `~` (contains) and
+`!~`, combined with `&`/`|` and parentheses. The `=`/`!=` operators support `*` wildcards.
+See [Using `dotnet test`](using-dotnet-test.md#filtering-tests) for the full grammar.
+
+#### Microsoft Testing Platform simple filters
+
+These typed switches mirror xUnit v3's Microsoft Testing Platform filter options. Each is
+**repeatable** and supports `*` wildcards:
+
+| Option | Runs / excludes |
+|--------|-----------------|
+| `--filter-class <name>` | Tests in the given class |
+| `--filter-not-class <name>` | Excludes tests in the given class |
+| `--filter-method <name>` | The given method (fully qualified) |
+| `--filter-not-method <name>` | Excludes the given method |
+| `--filter-namespace <name>` | Tests in the given namespace |
+| `--filter-not-namespace <name>` | Excludes tests in the given namespace |
+| `--filter-trait <name=value>` | Tests with the given trait value |
+| `--filter-not-trait <name=value>` | Excludes tests with the given trait value |
+
+```bash
+# Every test in two classes (repeat the switch)
+device-runners windows test --app app.msix \
+  --filter-class MyApp.Tests.CalculatorTests \
+  --filter-class MyApp.Tests.ParserTests
+
+# Every "Smoke" test, but not the slow ones, using a class wildcard
+device-runners windows test --app app.msix \
+  --filter-class Calc* \
+  --filter-trait Category=Smoke \
+  --filter-not-trait Category=Slow
+```
+
+Combining rules:
+
+- **Same kind** → values OR together (`--filter-class A --filter-class B` runs class `A` **or** `B`).
+- **Different kinds** → AND together (a class filter and a trait filter must both match).
+- **`not-` variants** → exclude matching tests (AND-ed negations).
+- `--filter` and the simple filters **cannot be combined** — the command fails with a clear
+  error if you supply both.
+
 ### Application Management
 
 Install, launch, and uninstall applications:

--- a/docs/articles/using-dotnet-test.md
+++ b/docs/articles/using-dotnet-test.md
@@ -92,14 +92,38 @@ The on-device evaluator mirrors the documented `dotnet test --filter` syntax:
 
 | Operator | Meaning |
 |----------|---------|
-| `=` | Equals (case-insensitive) |
-| `!=` | Not equals |
+| `=` | Equals (case-insensitive, supports `*` wildcards) |
+| `!=` | Not equals (supports `*` wildcards) |
 | `~` | Contains |
 | `!~` | Does not contain |
 
 Conditions can be combined with `&` (and), `|` (or) and grouped with parentheses. `&`
 binds tighter than `|`. Use `\` to escape a special character. Filtering works across all
 supported frameworks (xUnit v2, xUnit v3 and NUnit) and platforms.
+
+#### Wildcards
+
+The equals operators (`=` and `!=`) support `*` wildcards, where `*` matches zero or more
+characters. This is a superset of the standard `dotnet test --filter` grammar — any filter
+without a `*` behaves exactly as before.
+
+```bash
+# Every class whose name starts with "Calc"
+dotnet test MyApp.DeviceTests.csproj -f net10.0-maccatalyst \
+  --filter "ClassName=Calc*"
+
+# Every test whose fully qualified name ends with ".Adds"
+dotnet test MyApp.DeviceTests.csproj -f net10.0-maccatalyst \
+  --filter "FullyQualifiedName=*.Adds"
+
+# Every trait value containing "Smoke"
+dotnet test MyApp.DeviceTests.csproj -f net10.0-maccatalyst \
+  --filter "Category=*Smoke*"
+```
+
+`*` is only special for `=`/`!=`; the contains operators (`~`/`!~`) always treat it
+literally. Because a literal `*` cannot appear in CLR type or method names, there is no way
+to match a literal `*` with `=` — it is always interpreted as a wildcard.
 
 A filter that matches no tests is a **successful empty run** (exit code `0`), mirroring
 `dotnet test --filter`, which prints "No test matches the given testcase filter". An

--- a/docs/articles/using-dotnet-test.md
+++ b/docs/articles/using-dotnet-test.md
@@ -122,8 +122,9 @@ dotnet test MyApp.DeviceTests.csproj -f net10.0-maccatalyst \
 ```
 
 `*` is only special for `=`/`!=`; the contains operators (`~`/`!~`) always treat it
-literally. Because a literal `*` cannot appear in CLR type or method names, there is no way
-to match a literal `*` with `=` — it is always interpreted as a wildcard.
+literally. To match a **literal** `*` with `=`/`!=` — for example a trait value or display
+name that actually contains a `*` — escape it as `\*` (e.g. `--filter "Category=A\*B"`).
+Alternatively, use the contains operators, which never treat `*` as a wildcard.
 
 A filter that matches no tests is a **successful empty run** (exit code `0`), mirroring
 `dotnet test --filter`, which prints "No test matches the given testcase filter". An

--- a/docs/articles/xunit-v3-support.md
+++ b/docs/articles/xunit-v3-support.md
@@ -233,6 +233,54 @@ xUnit v3 takes a cleaner approach: the **same discoverer and runner work on all 
 | WASM support | Requires `useReflection: true` | Automatic (transparent in-memory detection) |
 | `IAsyncLifetime` | Returns `Task` | Returns `ValueTask` |
 
+## Test Filtering (Microsoft Testing Platform parity)
+
+When you run xUnit v3 tests through `dotnet test`, the [Microsoft Testing Platform](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro)
+exposes a set of typed "simple" filter switches. The DeviceRunners CLI accepts the same
+switches on its `test` command and runs the matching subset on-device:
+
+| Microsoft Testing Platform switch | DeviceRunners CLI equivalent |
+|---|---|
+| `--filter-class` / `--filter-not-class` | `--filter-class` / `--filter-not-class` |
+| `--filter-method` / `--filter-not-method` | `--filter-method` / `--filter-not-method` |
+| `--filter-namespace` / `--filter-not-namespace` | `--filter-namespace` / `--filter-not-namespace` |
+| `--filter-trait` / `--filter-not-trait` | `--filter-trait` / `--filter-not-trait` |
+
+Each switch is repeatable and supports `*` wildcards. Same-kind values OR together,
+different kinds AND together, and the `not-` variants exclude. See
+[Using DeviceRunners CLI](using-devicerunners-cli.md#filtering-tests) for examples. The
+on-device evaluator applies the filter the same way for xUnit v2, xUnit v3 and NUnit, so the
+simple filters behave identically regardless of which framework discovered the test.
+
+> [!NOTE]
+> The DeviceRunners `--filter` expression (and its `--filter-*` simple-filter translation)
+> is evaluated by DeviceRunners' own on-device matcher, not by xUnit v3's filter engine. The
+> switch **names** and combine semantics match Microsoft Testing Platform, but the matching
+> happens against the framework-agnostic test metadata DeviceRunners collects.
+
+### `--filter-query` (advanced graph query)
+
+xUnit v3 also exposes an advanced `--filter-query` option that uses a path-like **graph
+query language** instead of the simple switches. DeviceRunners does **not** implement
+`--filter-query` — use the simple `--filter-*` switches (or the `--filter` expression)
+instead. It is documented here only so the syntax is familiar if you see it elsewhere.
+
+A query matches the tree `/<assembly>/<namespace>/<class>/<method>`, with an optional
+`[trait=value]` suffix:
+
+| Query | Matches |
+|---|---|
+| `/MyTests/MyApp.Calc/CalculatorTests/Adds` | The single `Adds` method |
+| `/*/*/CalculatorTests/*` | Every test in `CalculatorTests` |
+| `/*/MyApp.Calc/*/*` | Everything in the `MyApp.Calc` namespace |
+| `/[Category=Smoke]` | Every test with trait `Category=Smoke` |
+| `/[Category!=Slow]` | Every test that does **not** have `Category=Slow` |
+
+`*` wildcards are allowed at the start/end of any segment, and `|`/`&` can combine patterns
+within a single (parenthesized) segment. `--filter-query` cannot be mixed with the simple
+filters. For the closest DeviceRunners equivalents, map class/namespace/method/trait segments
+onto the matching `--filter-*` switch.
+
 ## Known Limitations
 
 The DeviceRunners visual runner executes xUnit v3 tests in-process within a MAUI app. This is different from a standard xUnit v3 test project which runs as a standalone executable via `dotnet test`. Note that `dotnet test` still works for the **host TFM** (`net10.0`) of your test libraries — only the **device TFMs** use the in-process visual runner.

--- a/src/DeviceRunners.Cli/Commands/BaseTestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/BaseTestCommand.cs
@@ -12,7 +12,7 @@ namespace DeviceRunners.Cli.Commands;
 public abstract class BaseTestCommand<TSettings>(IAnsiConsole console) : BaseCommand<TSettings>(console)
 	where TSettings : BaseTestCommand<TSettings>.BaseTestCommandSettings
 {
-	public abstract class BaseTestCommandSettings : BaseCommandSettings
+	public abstract class BaseTestCommandSettings : BaseCommandSettings, IMtpSimpleFilterSettings
 	{
 		[Description("Path to the application package")]
 		[CommandOption("--app")]
@@ -53,6 +53,49 @@ public abstract class BaseTestCommand<TSettings>(IAnsiConsole console) : BaseCom
 		[Description("Run only the tests matching the given dotnet test --filter style expression")]
 		[CommandOption("--filter")]
 		public string? Filter { get; set; }
+
+		[Description("Run all tests in the given test class (Microsoft Testing Platform filter; repeatable; supports * wildcards)")]
+		[CommandOption("--filter-class")]
+		public string[]? FilterClass { get; set; }
+
+		[Description("Exclude all tests in the given test class (Microsoft Testing Platform filter; repeatable; supports * wildcards)")]
+		[CommandOption("--filter-not-class")]
+		public string[]? FilterNotClass { get; set; }
+
+		[Description("Run the given test method by fully qualified name (Microsoft Testing Platform filter; repeatable; supports * wildcards)")]
+		[CommandOption("--filter-method")]
+		public string[]? FilterMethod { get; set; }
+
+		[Description("Exclude the given test method by fully qualified name (Microsoft Testing Platform filter; repeatable; supports * wildcards)")]
+		[CommandOption("--filter-not-method")]
+		public string[]? FilterNotMethod { get; set; }
+
+		[Description("Run all tests in the given namespace (Microsoft Testing Platform filter; repeatable; supports * wildcards)")]
+		[CommandOption("--filter-namespace")]
+		public string[]? FilterNamespace { get; set; }
+
+		[Description("Exclude all tests in the given namespace (Microsoft Testing Platform filter; repeatable; supports * wildcards)")]
+		[CommandOption("--filter-not-namespace")]
+		public string[]? FilterNotNamespace { get; set; }
+
+		[Description("Run all tests with the given trait value, formatted name=value (Microsoft Testing Platform filter; repeatable; supports * wildcards)")]
+		[CommandOption("--filter-trait")]
+		public string[]? FilterTrait { get; set; }
+
+		[Description("Exclude all tests with the given trait value, formatted name=value (Microsoft Testing Platform filter; repeatable; supports * wildcards)")]
+		[CommandOption("--filter-not-trait")]
+		public string[]? FilterNotTrait { get; set; }
+
+		public override ValidationResult Validate()
+		{
+			if (MtpFilterTranslator.HasSimpleFilters(this) && !string.IsNullOrWhiteSpace(Filter))
+				return ValidationResult.Error(
+					"Cannot combine --filter with the --filter-class/--filter-not-class/--filter-method/" +
+					"--filter-not-method/--filter-namespace/--filter-not-namespace/--filter-trait/" +
+					"--filter-not-trait options. Use one filtering style or the other.");
+
+			return base.Validate();
+		}
 	}
 
 	public override int Execute(CommandContext context, TSettings settings, CancellationToken cancellationToken)
@@ -61,6 +104,16 @@ public abstract class BaseTestCommand<TSettings>(IAnsiConsole console) : BaseCom
 	}
 
 	protected abstract Task<int> ExecuteAsync(CommandContext context, TSettings settings);
+
+	/// <summary>
+	/// Resolves the effective <c>--filter</c> expression for a run: the translated
+	/// Microsoft Testing Platform simple filters when any are present, otherwise the
+	/// raw <c>--filter</c> expression. (Validation prevents specifying both.)
+	/// </summary>
+	internal static string? GetEffectiveFilter(TSettings settings) =>
+		MtpFilterTranslator.HasSimpleFilters(settings)
+			? MtpFilterTranslator.Translate(settings)
+			: settings.Filter;
 
 	/// <summary>
 	/// Builds the environment variables that tell the test app how to connect
@@ -75,8 +128,9 @@ public abstract class BaseTestCommand<TSettings>(IAnsiConsole console) : BaseCom
 			["DEVICE_RUNNERS_HOST_NAMES"] = settings.AppHostNames ?? "localhost",
 		};
 
-		if (!string.IsNullOrWhiteSpace(settings.Filter))
-			variables["DEVICE_RUNNERS_FILTER"] = settings.Filter!;
+		var filter = GetEffectiveFilter(settings);
+		if (!string.IsNullOrWhiteSpace(filter))
+			variables["DEVICE_RUNNERS_FILTER"] = filter!;
 
 		return variables;
 	}

--- a/src/DeviceRunners.Cli/Commands/BaseTestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/BaseTestCommand.cs
@@ -94,6 +94,10 @@ public abstract class BaseTestCommand<TSettings>(IAnsiConsole console) : BaseCom
 					"--filter-not-method/--filter-namespace/--filter-not-namespace/--filter-trait/" +
 					"--filter-not-trait options. Use one filtering style or the other.");
 
+			var traitError = MtpFilterTranslator.ValidateTraits(this);
+			if (traitError is not null)
+				return ValidationResult.Error(traitError);
+
 			return base.Validate();
 		}
 	}

--- a/src/DeviceRunners.Cli/Commands/MtpFilterTranslator.cs
+++ b/src/DeviceRunners.Cli/Commands/MtpFilterTranslator.cs
@@ -1,0 +1,128 @@
+using System.Text;
+
+namespace DeviceRunners.Cli.Commands;
+
+/// <summary>
+/// Settings that expose the Microsoft Testing Platform "simple" test filters
+/// (xUnit v3's <c>--filter-class</c> / <c>--filter-method</c> /
+/// <c>--filter-namespace</c> / <c>--filter-trait</c> family and their
+/// <c>not-</c> variants).
+/// </summary>
+public interface IMtpSimpleFilterSettings
+{
+	string[]? FilterClass { get; }
+	string[]? FilterNotClass { get; }
+	string[]? FilterMethod { get; }
+	string[]? FilterNotMethod { get; }
+	string[]? FilterNamespace { get; }
+	string[]? FilterNotNamespace { get; }
+	string[]? FilterTrait { get; }
+	string[]? FilterNotTrait { get; }
+}
+
+/// <summary>
+/// Translates the Microsoft Testing Platform "simple" filters into the
+/// DeviceRunners <c>--filter</c> expression that the on-device
+/// <c>TestCaseFilter</c> understands.
+/// </summary>
+/// <remarks>
+/// Property mapping: class → <c>ClassName</c>, method → <c>FullyQualifiedName</c>,
+/// namespace → <c>Namespace</c>, trait <c>n=v</c> → property <c>n</c> value <c>v</c>.
+/// Multiple values of the same kind OR together; different kinds AND together;
+/// the <c>not-</c> variants exclude (AND-ed negations). <c>*</c> wildcards are
+/// left intact so the on-device evaluator can apply them.
+/// </remarks>
+public static class MtpFilterTranslator
+{
+	/// <summary>
+	/// Whether any of the simple filter options were specified.
+	/// </summary>
+	public static bool HasSimpleFilters(IMtpSimpleFilterSettings settings) =>
+		HasValues(settings.FilterClass) || HasValues(settings.FilterNotClass) ||
+		HasValues(settings.FilterMethod) || HasValues(settings.FilterNotMethod) ||
+		HasValues(settings.FilterNamespace) || HasValues(settings.FilterNotNamespace) ||
+		HasValues(settings.FilterTrait) || HasValues(settings.FilterNotTrait);
+
+	/// <summary>
+	/// Builds the combined <c>--filter</c> expression, or <c>null</c> when no
+	/// simple filters were specified.
+	/// </summary>
+	public static string? Translate(IMtpSimpleFilterSettings settings)
+	{
+		var groups = new List<string>();
+
+		AddPropertyGroup(groups, "ClassName", settings.FilterClass, negate: false);
+		AddPropertyGroup(groups, "ClassName", settings.FilterNotClass, negate: true);
+		AddPropertyGroup(groups, "FullyQualifiedName", settings.FilterMethod, negate: false);
+		AddPropertyGroup(groups, "FullyQualifiedName", settings.FilterNotMethod, negate: true);
+		AddPropertyGroup(groups, "Namespace", settings.FilterNamespace, negate: false);
+		AddPropertyGroup(groups, "Namespace", settings.FilterNotNamespace, negate: true);
+		AddTraitGroup(groups, settings.FilterTrait, negate: false);
+		AddTraitGroup(groups, settings.FilterNotTrait, negate: true);
+
+		return groups.Count == 0 ? null : string.Join(" & ", groups);
+	}
+
+	static void AddPropertyGroup(List<string> groups, string property, string[]? values, bool negate)
+	{
+		var cleaned = Clean(values);
+		if (cleaned.Count == 0)
+			return;
+
+		var op = negate ? "!=" : "=";
+		var conditions = cleaned.Select(v => $"{property}{op}{Escape(v)}").ToList();
+		groups.Add(Combine(conditions, negate));
+	}
+
+	static void AddTraitGroup(List<string> groups, string[]? values, bool negate)
+	{
+		var cleaned = Clean(values);
+		if (cleaned.Count == 0)
+			return;
+
+		var op = negate ? "!=" : "=";
+		var conditions = new List<string>(cleaned.Count);
+		foreach (var entry in cleaned)
+		{
+			var eq = entry.IndexOf('=');
+			var name = eq >= 0 ? entry[..eq] : entry;
+			var value = eq >= 0 ? entry[(eq + 1)..] : string.Empty;
+			conditions.Add($"{Escape(name)}{op}{Escape(value)}");
+		}
+
+		groups.Add(Combine(conditions, negate));
+	}
+
+	// Inclusive conditions of the same kind OR together; exclusions AND together
+	// (a test is dropped when it matches any of them). Multi-condition groups are
+	// parenthesized so they compose safely with the cross-kind AND join.
+	static string Combine(List<string> conditions, bool negate)
+	{
+		if (conditions.Count == 1)
+			return conditions[0];
+
+		var joined = string.Join(negate ? "&" : "|", conditions);
+		return $"({joined})";
+	}
+
+	static List<string> Clean(string[]? values) =>
+		values is null
+			? new List<string>()
+			: values.Where(v => !string.IsNullOrWhiteSpace(v)).Select(v => v.Trim()).ToList();
+
+	static bool HasValues(string[]? values) => Clean(values).Count > 0;
+
+	// Escapes the expression's structural characters so names and values are
+	// treated literally. '*' is intentionally left intact so it stays a wildcard.
+	static string Escape(string value)
+	{
+		var sb = new StringBuilder(value.Length);
+		foreach (var c in value)
+		{
+			if (c is '\\' or '(' or ')' or '&' or '|' or '=' or '~' or '!')
+				sb.Append('\\');
+			sb.Append(c);
+		}
+		return sb.ToString();
+	}
+}

--- a/src/DeviceRunners.Cli/Commands/MtpFilterTranslator.cs
+++ b/src/DeviceRunners.Cli/Commands/MtpFilterTranslator.cs
@@ -44,6 +44,25 @@ public static class MtpFilterTranslator
 		HasValues(settings.FilterTrait) || HasValues(settings.FilterNotTrait);
 
 	/// <summary>
+	/// Validates the trait filters, which must use the <c>name=value</c> form.
+	/// Returns an error message for the first malformed entry, or <c>null</c> when
+	/// every trait filter is well-formed. This prevents a nameless trait (e.g.
+	/// <c>=Fast</c>) from being silently reinterpreted as a different filter kind.
+	/// </summary>
+	public static string? ValidateTraits(IMtpSimpleFilterSettings settings)
+	{
+		foreach (var entry in Clean(settings.FilterTrait).Concat(Clean(settings.FilterNotTrait)))
+		{
+			// A valid trait needs a non-empty name before the '=' separator, so the
+			// separator must be present (eq >= 0) and not the first character (eq > 0).
+			if (entry.IndexOf('=') <= 0)
+				return $"Invalid trait filter '{entry}'. Traits must be specified as name=value.";
+		}
+
+		return null;
+	}
+
+	/// <summary>
 	/// Builds the combined <c>--filter</c> expression, or <c>null</c> when no
 	/// simple filters were specified.
 	/// </summary>

--- a/src/DeviceRunners.Cli/Commands/Wasm/WasmTestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Wasm/WasmTestCommand.cs
@@ -134,8 +134,9 @@ public class WasmTestCommand(IAnsiConsole console) : BaseTestCommand<WasmTestCom
 			};
 
 			var testUrl = $"{url}?device-runners-autorun=1";
-			if (!string.IsNullOrWhiteSpace(settings.Filter))
-				testUrl += $"&device-runners-filter={Uri.EscapeDataString(settings.Filter)}";
+			var filter = GetEffectiveFilter(settings);
+			if (!string.IsNullOrWhiteSpace(filter))
+				testUrl += $"&device-runners-filter={Uri.EscapeDataString(filter)}";
 			await browser.LaunchAsync(testUrl, headless: !settings.Headed);
 			WriteConsoleOutput($"    Browser launched, running tests...", settings);
 

--- a/src/DeviceRunners.Cli/Commands/Windows/TestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Windows/TestCommand.cs
@@ -170,8 +170,9 @@ public class WindowsTestCommand(IAnsiConsole console) : BaseTestCommand<WindowsT
 			var appPort = settings.AppPort ?? settings.Port;
 			var appHostNames = settings.AppHostNames ?? "localhost";
 			var appArgs = $"--device-runners-autorun --device-runners-port {appPort} --device-runners-host-names {appHostNames}";
-			if (!string.IsNullOrWhiteSpace(settings.Filter))
-				appArgs += $" --device-runners-filter \"{settings.Filter}\"";
+			var filter = GetEffectiveFilter(settings);
+			if (!string.IsNullOrWhiteSpace(filter))
+				appArgs += $" --device-runners-filter \"{filter}\"";
 			pid = await winAppService.RunDetachedAsync(inputFolder, manifestPath, appArgs: appArgs);
 		}
 		catch (Exception ex)

--- a/src/DeviceRunners.VisualRunners/Filtering/TestCaseFilter.cs
+++ b/src/DeviceRunners.VisualRunners/Filtering/TestCaseFilter.cs
@@ -375,10 +375,14 @@ public static class TestCaseFilter
 
 		// Translates a wildcard value into an anchored, case-insensitive regex where
 		// '*' matches zero or more characters and every other character is literal.
+		// NonBacktracking guarantees linear-time matching, so a pathological filter
+		// (e.g. many '*' segments) cannot trigger catastrophic backtracking.
 		static Regex BuildWildcardRegex(string value)
 		{
 			var pattern = string.Join(".*", value.Split('*').Select(Regex.Escape));
-			return new Regex($"^{pattern}$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+			return new Regex(
+				$"^{pattern}$",
+				RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
 		}
 	}
 }

--- a/src/DeviceRunners.VisualRunners/Filtering/TestCaseFilter.cs
+++ b/src/DeviceRunners.VisualRunners/Filtering/TestCaseFilter.cs
@@ -18,11 +18,17 @@ namespace DeviceRunners.VisualRunners;
 /// <c>&amp;</c> binds tighter than <c>|</c>. Use <c>\</c> to escape a special character.</item>
 /// <item>Wildcards: a <c>*</c> in the value of an equals condition (<c>=</c> or <c>!=</c>)
 /// matches zero or more characters (e.g. <c>ClassName=Calc*</c>). This is a DeviceRunners
-/// extension over VSTest; a value without <c>*</c> still matches exactly as before.</item>
+/// extension over VSTest; a value without <c>*</c> still matches exactly as before. Use
+/// <c>\*</c> to match a literal <c>*</c>.</item>
 /// </list>
 /// </remarks>
 public static class TestCaseFilter
 {
+	// Sentinel used internally to represent an escaped '*' (i.e. "\*") so it is matched
+	// literally instead of being treated as a wildcard. Uses a Unicode private-use code
+	// point that will never appear in a real test identifier or trait value.
+	const char EscapedWildcard = '\uE000';
+
 	/// <summary>
 	/// Parses the given filter expression into an evaluable <see cref="ITestCaseFilter"/>.
 	/// An empty or whitespace expression returns a filter that matches everything.
@@ -141,7 +147,10 @@ public static class TestCaseFilter
 			{
 				if (i + 1 < expression.Length)
 				{
-					target.Append(expression[i + 1]);
+					// Preserve an escaped '*' as a sentinel so it matches literally instead
+					// of acting as a wildcard; all other escaped characters pass through.
+					var next = expression[i + 1];
+					target.Append(next == '*' ? EscapedWildcard : next);
 					i += 2;
 				}
 				else
@@ -306,12 +315,19 @@ public static class TestCaseFilter
 
 	sealed class ConditionFilter(string property, FilterOperator op, string value) : ITestCaseFilter
 	{
-		// Wildcards only apply to the equals family. A '*' in the value matches zero or
-		// more characters; a value without '*' keeps the original exact-match behavior.
+		// Wildcards only apply to the equals family. An unescaped '*' in the value matches
+		// zero or more characters; a value without one keeps the original exact-match
+		// behavior. Escaped stars ('\*') arrive as EscapedWildcard sentinels, so they are
+		// not counted as wildcards here and are matched literally.
 		readonly Regex? _wildcard =
 			(op is FilterOperator.Equals or FilterOperator.NotEquals) && value.Contains('*')
 				? BuildWildcardRegex(value)
 				: null;
+
+		// For every direct (non-regex) comparison, collapse the sentinel back to a literal
+		// '*'. It only needs to survive long enough to build the wildcard regex above.
+		readonly string _property = property.Replace(EscapedWildcard, '*');
+		readonly string _value = value.Replace(EscapedWildcard, '*');
 
 		public bool Matches(ITestCaseInfo testCase)
 		{
@@ -330,32 +346,32 @@ public static class TestCaseFilter
 		bool Equals(string? actual) =>
 			actual is not null && (_wildcard is not null
 				? _wildcard.IsMatch(actual)
-				: string.Equals(actual, value, StringComparison.OrdinalIgnoreCase));
+				: string.Equals(actual, _value, StringComparison.OrdinalIgnoreCase));
 
 		bool Contains(string? actual) =>
-			actual is not null && actual.Contains(value, StringComparison.OrdinalIgnoreCase);
+			actual is not null && actual.Contains(_value, StringComparison.OrdinalIgnoreCase);
 
 		IEnumerable<string?> ResolveValues(ITestCaseInfo testCase)
 		{
-			if (property.Length == 0 || string.Equals(property, "FullyQualifiedName", StringComparison.OrdinalIgnoreCase))
+			if (_property.Length == 0 || string.Equals(_property, "FullyQualifiedName", StringComparison.OrdinalIgnoreCase))
 				return new[] { GetFullyQualifiedName(testCase) };
 
-			if (string.Equals(property, "DisplayName", StringComparison.OrdinalIgnoreCase))
+			if (string.Equals(_property, "DisplayName", StringComparison.OrdinalIgnoreCase))
 				return new[] { testCase.DisplayName };
 
-			if (string.Equals(property, "Name", StringComparison.OrdinalIgnoreCase))
+			if (string.Equals(_property, "Name", StringComparison.OrdinalIgnoreCase))
 				return new[] { testCase.TestMethodName };
 
-			if (string.Equals(property, "ClassName", StringComparison.OrdinalIgnoreCase))
+			if (string.Equals(_property, "ClassName", StringComparison.OrdinalIgnoreCase))
 				return new[] { testCase.TestClassName };
 
-			if (string.Equals(property, "Namespace", StringComparison.OrdinalIgnoreCase))
+			if (string.Equals(_property, "Namespace", StringComparison.OrdinalIgnoreCase))
 				return new[] { testCase.TestClassNamespace };
 
 			// Otherwise treat the property as a trait name (case-insensitive lookup).
 			foreach (var trait in testCase.Traits)
 			{
-				if (string.Equals(trait.Key, property, StringComparison.OrdinalIgnoreCase))
+				if (string.Equals(trait.Key, _property, StringComparison.OrdinalIgnoreCase))
 					return trait.Value;
 			}
 
@@ -373,13 +389,16 @@ public static class TestCaseFilter
 			return className ?? methodName ?? testCase.DisplayName;
 		}
 
-		// Translates a wildcard value into an anchored, case-insensitive regex where
-		// '*' matches zero or more characters and every other character is literal.
+		// Translates a wildcard value into an anchored, case-insensitive regex where an
+		// unescaped '*' matches zero or more characters and every other character is
+		// literal. Escaped-star sentinels inside a segment collapse back to a literal '*'.
 		// NonBacktracking guarantees linear-time matching, so a pathological filter
 		// (e.g. many '*' segments) cannot trigger catastrophic backtracking.
 		static Regex BuildWildcardRegex(string value)
 		{
-			var pattern = string.Join(".*", value.Split('*').Select(Regex.Escape));
+			var pattern = string.Join(
+				".*",
+				value.Split('*').Select(segment => Regex.Escape(segment.Replace(EscapedWildcard, '*'))));
 			return new Regex(
 				$"^{pattern}$",
 				RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);

--- a/src/DeviceRunners.VisualRunners/Filtering/TestCaseFilter.cs
+++ b/src/DeviceRunners.VisualRunners/Filtering/TestCaseFilter.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace DeviceRunners.VisualRunners;
 
@@ -15,6 +16,9 @@ namespace DeviceRunners.VisualRunners;
 /// and any trait name (e.g. <c>Category</c>).</item>
 /// <item>Logic: <c>&amp;</c> (and), <c>|</c> (or), grouping with <c>(</c> and <c>)</c>.
 /// <c>&amp;</c> binds tighter than <c>|</c>. Use <c>\</c> to escape a special character.</item>
+/// <item>Wildcards: a <c>*</c> in the value of an equals condition (<c>=</c> or <c>!=</c>)
+/// matches zero or more characters (e.g. <c>ClassName=Calc*</c>). This is a DeviceRunners
+/// extension over VSTest; a value without <c>*</c> still matches exactly as before.</item>
 /// </list>
 /// </remarks>
 public static class TestCaseFilter
@@ -302,6 +306,13 @@ public static class TestCaseFilter
 
 	sealed class ConditionFilter(string property, FilterOperator op, string value) : ITestCaseFilter
 	{
+		// Wildcards only apply to the equals family. A '*' in the value matches zero or
+		// more characters; a value without '*' keeps the original exact-match behavior.
+		readonly Regex? _wildcard =
+			(op is FilterOperator.Equals or FilterOperator.NotEquals) && value.Contains('*')
+				? BuildWildcardRegex(value)
+				: null;
+
 		public bool Matches(ITestCaseInfo testCase)
 		{
 			var actualValues = ResolveValues(testCase);
@@ -317,7 +328,9 @@ public static class TestCaseFilter
 		}
 
 		bool Equals(string? actual) =>
-			actual is not null && string.Equals(actual, value, StringComparison.OrdinalIgnoreCase);
+			actual is not null && (_wildcard is not null
+				? _wildcard.IsMatch(actual)
+				: string.Equals(actual, value, StringComparison.OrdinalIgnoreCase));
 
 		bool Contains(string? actual) =>
 			actual is not null && actual.Contains(value, StringComparison.OrdinalIgnoreCase);
@@ -358,6 +371,14 @@ public static class TestCaseFilter
 				return $"{className}.{methodName}";
 
 			return className ?? methodName ?? testCase.DisplayName;
+		}
+
+		// Translates a wildcard value into an anchored, case-insensitive regex where
+		// '*' matches zero or more characters and every other character is literal.
+		static Regex BuildWildcardRegex(string value)
+		{
+			var pattern = string.Join(".*", value.Split('*').Select(Regex.Escape));
+			return new Regex($"^{pattern}$", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 		}
 	}
 }

--- a/test/DeviceRunners.Cli.Tests/Commands/AppEnvironmentVariableTests.cs
+++ b/test/DeviceRunners.Cli.Tests/Commands/AppEnvironmentVariableTests.cs
@@ -45,4 +45,82 @@ public class AppEnvironmentVariableTests
 
 		Assert.False(env.ContainsKey("DEVICE_RUNNERS_FILTER"));
 	}
+
+	[Fact]
+	public void SimpleFilters_AreTranslatedIntoEnvironment()
+	{
+		var settings = new WindowsTestCommand.Settings
+		{
+			App = "app.msix",
+			FilterClass = new[] { "Calc*" },
+		};
+
+		var env = BaseTestCommand<WindowsTestCommand.Settings>.GetAppEnvironmentVariables(settings);
+
+		Assert.Equal("ClassName=Calc*", env["DEVICE_RUNNERS_FILTER"]);
+	}
+
+	[Fact]
+	public void SimpleFilters_MultipleKinds_AreCombinedInEnvironment()
+	{
+		var settings = new WindowsTestCommand.Settings
+		{
+			App = "app.msix",
+			FilterClass = new[] { "A" },
+			FilterTrait = new[] { "Cat=Fast" },
+		};
+
+		var env = BaseTestCommand<WindowsTestCommand.Settings>.GetAppEnvironmentVariables(settings);
+
+		Assert.Equal("ClassName=A & Cat=Fast", env["DEVICE_RUNNERS_FILTER"]);
+	}
+
+	[Fact]
+	public void GetEffectiveFilter_PrefersSimpleFilters_OverRawFilter()
+	{
+		var settings = new WindowsTestCommand.Settings
+		{
+			App = "app.msix",
+			FilterClass = new[] { "Calc" },
+		};
+
+		Assert.Equal("ClassName=Calc", BaseTestCommand<WindowsTestCommand.Settings>.GetEffectiveFilter(settings));
+	}
+
+	[Fact]
+	public void GetEffectiveFilter_FallsBackToRawFilter_WhenNoSimpleFilters()
+	{
+		var settings = new WindowsTestCommand.Settings
+		{
+			App = "app.msix",
+			Filter = "FullyQualifiedName~MyClass",
+		};
+
+		Assert.Equal("FullyQualifiedName~MyClass", BaseTestCommand<WindowsTestCommand.Settings>.GetEffectiveFilter(settings));
+	}
+
+	[Fact]
+	public void Validate_RejectsMixingRawAndSimpleFilters()
+	{
+		var settings = new WindowsTestCommand.Settings
+		{
+			App = "app.msix",
+			Filter = "FullyQualifiedName~MyClass",
+			FilterClass = new[] { "Calc" },
+		};
+
+		Assert.False(settings.Validate().Successful);
+	}
+
+	[Fact]
+	public void Validate_AllowsSimpleFiltersWithoutRawFilter()
+	{
+		var settings = new WindowsTestCommand.Settings
+		{
+			App = "app.msix",
+			FilterClass = new[] { "Calc" },
+		};
+
+		Assert.True(settings.Validate().Successful);
+	}
 }

--- a/test/DeviceRunners.Cli.Tests/Commands/AppEnvironmentVariableTests.cs
+++ b/test/DeviceRunners.Cli.Tests/Commands/AppEnvironmentVariableTests.cs
@@ -123,4 +123,16 @@ public class AppEnvironmentVariableTests
 
 		Assert.True(settings.Validate().Successful);
 	}
+
+	[Fact]
+	public void Validate_RejectsMalformedTraitFilter()
+	{
+		var settings = new WindowsTestCommand.Settings
+		{
+			App = "app.msix",
+			FilterTrait = new[] { "Category" },
+		};
+
+		Assert.False(settings.Validate().Successful);
+	}
 }

--- a/test/DeviceRunners.Cli.Tests/Commands/MtpFilterTranslatorTests.cs
+++ b/test/DeviceRunners.Cli.Tests/Commands/MtpFilterTranslatorTests.cs
@@ -1,0 +1,135 @@
+using DeviceRunners.Cli.Commands;
+
+namespace DeviceRunners.Cli.Tests;
+
+public class MtpFilterTranslatorTests
+{
+	sealed class Filters : IMtpSimpleFilterSettings
+	{
+		public string[]? FilterClass { get; set; }
+		public string[]? FilterNotClass { get; set; }
+		public string[]? FilterMethod { get; set; }
+		public string[]? FilterNotMethod { get; set; }
+		public string[]? FilterNamespace { get; set; }
+		public string[]? FilterNotNamespace { get; set; }
+		public string[]? FilterTrait { get; set; }
+		public string[]? FilterNotTrait { get; set; }
+	}
+
+	[Fact]
+	public void NoFilters_ReturnsNull()
+	{
+		Assert.Null(MtpFilterTranslator.Translate(new Filters()));
+		Assert.False(MtpFilterTranslator.HasSimpleFilters(new Filters()));
+	}
+
+	[Fact]
+	public void WhitespaceOnly_IsIgnored()
+	{
+		var filters = new Filters { FilterClass = new[] { "  ", "" } };
+		Assert.Null(MtpFilterTranslator.Translate(filters));
+		Assert.False(MtpFilterTranslator.HasSimpleFilters(filters));
+	}
+
+	[Fact]
+	public void SingleClass_MapsToClassNameEquals()
+	{
+		var filters = new Filters { FilterClass = new[] { "MyApp.Calculator" } };
+		Assert.True(MtpFilterTranslator.HasSimpleFilters(filters));
+		Assert.Equal("ClassName=MyApp.Calculator", MtpFilterTranslator.Translate(filters));
+	}
+
+	[Fact]
+	public void MultipleClass_OrTogetherInParens()
+	{
+		var filters = new Filters { FilterClass = new[] { "A", "B" } };
+		Assert.Equal("(ClassName=A|ClassName=B)", MtpFilterTranslator.Translate(filters));
+	}
+
+	[Fact]
+	public void NotClass_Single_MapsToNotEquals()
+	{
+		var filters = new Filters { FilterNotClass = new[] { "A" } };
+		Assert.Equal("ClassName!=A", MtpFilterTranslator.Translate(filters));
+	}
+
+	[Fact]
+	public void NotClass_Multiple_AndTogetherInParens()
+	{
+		var filters = new Filters { FilterNotClass = new[] { "A", "B" } };
+		Assert.Equal("(ClassName!=A&ClassName!=B)", MtpFilterTranslator.Translate(filters));
+	}
+
+	[Fact]
+	public void Method_MapsToFullyQualifiedName()
+	{
+		var filters = new Filters { FilterMethod = new[] { "My.Ns.Cls.M" } };
+		Assert.Equal("FullyQualifiedName=My.Ns.Cls.M", MtpFilterTranslator.Translate(filters));
+	}
+
+	[Fact]
+	public void Namespace_MapsToNamespace()
+	{
+		var filters = new Filters { FilterNamespace = new[] { "My.Ns" } };
+		Assert.Equal("Namespace=My.Ns", MtpFilterTranslator.Translate(filters));
+	}
+
+	[Fact]
+	public void Trait_SplitsNameAndValue()
+	{
+		var filters = new Filters { FilterTrait = new[] { "Category=Fast" } };
+		Assert.Equal("Category=Fast", MtpFilterTranslator.Translate(filters));
+	}
+
+	[Fact]
+	public void NotTrait_MapsToNotEquals()
+	{
+		var filters = new Filters { FilterNotTrait = new[] { "Category=Slow" } };
+		Assert.Equal("Category!=Slow", MtpFilterTranslator.Translate(filters));
+	}
+
+	[Fact]
+	public void DifferentKinds_AndTogether()
+	{
+		var filters = new Filters
+		{
+			FilterClass = new[] { "A", "B" },
+			FilterTrait = new[] { "Cat=Fast" },
+		};
+		Assert.Equal("(ClassName=A|ClassName=B) & Cat=Fast", MtpFilterTranslator.Translate(filters));
+	}
+
+	[Fact]
+	public void InclusiveAndExclusive_Combine()
+	{
+		var filters = new Filters
+		{
+			FilterClass = new[] { "Calc" },
+			FilterNotMethod = new[] { "Calc.Slow" },
+		};
+		Assert.Equal("ClassName=Calc & FullyQualifiedName!=Calc.Slow", MtpFilterTranslator.Translate(filters));
+	}
+
+	[Fact]
+	public void Wildcards_ArePreserved()
+	{
+		var filters = new Filters { FilterClass = new[] { "Calc*", "*Helper" } };
+		Assert.Equal("(ClassName=Calc*|ClassName=*Helper)", MtpFilterTranslator.Translate(filters));
+	}
+
+	[Fact]
+	public void StructuralCharacters_AreEscaped()
+	{
+		// Parentheses, ampersands and pipes in names must be escaped so they are
+		// treated literally by the on-device grammar; '*' is left intact.
+		var filters = new Filters { FilterClass = new[] { "A(b)&c|d" } };
+		Assert.Equal(@"ClassName=A\(b\)\&c\|d", MtpFilterTranslator.Translate(filters));
+	}
+
+	[Fact]
+	public void TraitValueWithEquals_KeepsOperatorOnFirstEquals()
+	{
+		var filters = new Filters { FilterTrait = new[] { "Cat=a=b" } };
+		Assert.Equal(@"Cat=a\=b", MtpFilterTranslator.Translate(filters));
+	}
+}

--- a/test/DeviceRunners.Cli.Tests/Commands/MtpFilterTranslatorTests.cs
+++ b/test/DeviceRunners.Cli.Tests/Commands/MtpFilterTranslatorTests.cs
@@ -132,4 +132,36 @@ public class MtpFilterTranslatorTests
 		var filters = new Filters { FilterTrait = new[] { "Cat=a=b" } };
 		Assert.Equal(@"Cat=a\=b", MtpFilterTranslator.Translate(filters));
 	}
+
+	[Fact]
+	public void ValidateTraits_AcceptsWellFormedTraits()
+	{
+		var filters = new Filters
+		{
+			FilterTrait = new[] { "Category=Fast" },
+			FilterNotTrait = new[] { "Category=Slow" },
+		};
+		Assert.Null(MtpFilterTranslator.ValidateTraits(filters));
+	}
+
+	[Fact]
+	public void ValidateTraits_RejectsTraitWithoutSeparator()
+	{
+		var filters = new Filters { FilterTrait = new[] { "Category" } };
+		Assert.NotNull(MtpFilterTranslator.ValidateTraits(filters));
+	}
+
+	[Fact]
+	public void ValidateTraits_RejectsTraitWithEmptyName()
+	{
+		var filters = new Filters { FilterNotTrait = new[] { "=Fast" } };
+		Assert.NotNull(MtpFilterTranslator.ValidateTraits(filters));
+	}
+
+	[Fact]
+	public void ValidateTraits_IgnoresNonTraitFilters()
+	{
+		var filters = new Filters { FilterClass = new[] { "Calc" } };
+		Assert.Null(MtpFilterTranslator.ValidateTraits(filters));
+	}
 }

--- a/test/DeviceRunners.VisualRunners.Tests/Testing/TestCaseFilterTests.cs
+++ b/test/DeviceRunners.VisualRunners.Tests/Testing/TestCaseFilterTests.cs
@@ -174,6 +174,42 @@ public class TestCaseFilterTests
 		Assert.False(TestCaseFilter.Parse("ClassName~Calc*").Matches(caseInfo));
 	}
 
+	[Fact]
+	public void EscapedWildcardMatchesLiteralStar()
+	{
+		// "\*" escapes the wildcard so it matches a literal '*' rather than any characters.
+		var starCase = Case(traits: ("Category", new[] { "A*B" }));
+		Assert.True(TestCaseFilter.Parse(@"Category=A\*B").Matches(starCase));
+
+		// The same expression must NOT match a value where '*' stood in for other chars,
+		// proving the star is literal (not a wildcard).
+		var wideCase = Case(traits: ("Category", new[] { "AXYZB" }));
+		Assert.False(TestCaseFilter.Parse(@"Category=A\*B").Matches(wideCase));
+
+		// A bare '*' still wildcards, so it matches the "AXYZB" value.
+		Assert.True(TestCaseFilter.Parse("Category=A*B").Matches(wideCase));
+	}
+
+	[Fact]
+	public void EscapedWildcardMixedWithWildcard()
+	{
+		// "a\**" == literal 'a*' followed by a wildcard, matching anything that starts
+		// with the literal "a*".
+		var caseInfo = Case(traits: ("Category", new[] { "a*bcd" }));
+		Assert.True(TestCaseFilter.Parse(@"Category=a\**").Matches(caseInfo));
+		Assert.False(TestCaseFilter.Parse(@"Category=a\**").Matches(Case(traits: ("Category", new[] { "axbcd" }))));
+	}
+
+	[Fact]
+	public void EscapedWildcardOnExactValueDoesNotWildcard()
+	{
+		// A fully-escaped star with no bare '*' is an exact literal match, so a value
+		// that would match a wildcard ("anything") must not match here.
+		var literal = Case(traits: ("Category", new[] { "*" }));
+		Assert.True(TestCaseFilter.Parse(@"Category=\*").Matches(literal));
+		Assert.False(TestCaseFilter.Parse(@"Category=\*").Matches(Case(traits: ("Category", new[] { "Smoke" }))));
+	}
+
 	class StubTestCaseInfo : ITestCaseInfo
 	{
 		public ITestAssemblyInfo TestAssembly { get; set; } = null!;

--- a/test/DeviceRunners.VisualRunners.Tests/Testing/TestCaseFilterTests.cs
+++ b/test/DeviceRunners.VisualRunners.Tests/Testing/TestCaseFilterTests.cs
@@ -135,6 +135,43 @@ public class TestCaseFilterTests
 		Assert.True(filter.Matches(Case()));
 	}
 
+	[Theory]
+	[InlineData("ClassName=MyApp.Calc*", true)]   // starts-with
+	[InlineData("ClassName=*Calculator", true)]   // ends-with
+	[InlineData("ClassName=*Calc*", true)]        // contains
+	[InlineData("ClassName=*", true)]             // match-all
+	[InlineData("ClassName=MyApp.Other*", false)]
+	[InlineData("ClassName=myapp.calc*", true)]   // case-insensitive
+	[InlineData("ClassName=MyApp.Calculator", true)] // exact still works (parity)
+	[InlineData("ClassName=MyApp.Calc", false)]   // exact, no wildcard => no match
+	[InlineData("FullyQualifiedName=MyApp.*.Adds", true)] // mid-string wildcard
+	[InlineData("FullyQualifiedName=*.Adds", true)]
+	[InlineData("ClassName!=MyApp.Calc*", false)] // negated wildcard match excludes
+	[InlineData("ClassName!=Other*", true)]
+	public void WildcardMatching(string expression, bool expected)
+	{
+		var filter = TestCaseFilter.Parse(expression);
+		Assert.Equal(expected, filter.Matches(Case()));
+	}
+
+	[Fact]
+	public void WildcardMatchingTraits()
+	{
+		var caseInfo = Case(traits: ("Category", new[] { "Smoke", "Fast" }));
+		Assert.True(TestCaseFilter.Parse("Category=Sm*").Matches(caseInfo));
+		Assert.True(TestCaseFilter.Parse("Category=*ast").Matches(caseInfo));
+		Assert.False(TestCaseFilter.Parse("Category=Slo*").Matches(caseInfo));
+	}
+
+	[Fact]
+	public void WildcardOnlyAppliesToEqualsFamily()
+	{
+		// '~' (contains) keeps treating '*' literally, so the literal substring
+		// "Calc*" is never found in "MyApp.Calculator".
+		var caseInfo = Case(className: "MyApp.Calculator");
+		Assert.False(TestCaseFilter.Parse("ClassName~Calc*").Matches(caseInfo));
+	}
+
 	class StubTestCaseInfo : ITestCaseInfo
 	{
 		public ITestAssemblyInfo TestAssembly { get; set; } = null!;

--- a/test/DeviceRunners.VisualRunners.Tests/Testing/TestCaseFilterTests.cs
+++ b/test/DeviceRunners.VisualRunners.Tests/Testing/TestCaseFilterTests.cs
@@ -140,6 +140,8 @@ public class TestCaseFilterTests
 	[InlineData("ClassName=*Calculator", true)]   // ends-with
 	[InlineData("ClassName=*Calc*", true)]        // contains
 	[InlineData("ClassName=*", true)]             // match-all
+	[InlineData("ClassName=M*A*C*r", true)]       // multiple wildcard segments
+	[InlineData("ClassName=*Z*Z*Z*Z*Z*Z*Z*", false)] // many segments, no match (no backtracking blow-up)
 	[InlineData("ClassName=MyApp.Other*", false)]
 	[InlineData("ClassName=myapp.calc*", true)]   // case-insensitive
 	[InlineData("ClassName=MyApp.Calculator", true)] // exact still works (parity)


### PR DESCRIPTION
## Summary

Adds support for the eight xUnit v3 **Microsoft Testing Platform (MTP)** "simple" test-filter switches to the `device-runners` CLI, and adds `*` wildcard support to the on-device filter evaluator.

This was triggered by reports of a new `--filter-class` arg. That switch is part of MTP's typed "simple" filter family (an alternative to the VSTest-style `--filter` expression). This PR brings all 8 of them to DeviceRunners and makes the matching faithful via real wildcard support.

## What changed

**On-device evaluator (`TestCaseFilter`)**
- Added `*` wildcard support to the equals family (`=` / `!=`) via an anchored, case-insensitive regex. `*` matches zero or more characters.
- This is a **superset** of the VSTest grammar — any filter without `*` matches exactly as before (parity preserved).
- The wildcard regex uses `RegexOptions.NonBacktracking` for guaranteed linear-time matching (no catastrophic-backtracking / ReDoS risk on adversarial patterns).
- As a bonus, `dotnet test --filter "ClassName=Calc*"` now works too.

**CLI (`device-runners <platform> test`)**
- Added the 8 repeatable MTP switches: `--filter-class` / `--filter-not-class`, `--filter-method` / `--filter-not-method`, `--filter-namespace` / `--filter-not-namespace`, `--filter-trait` / `--filter-not-trait`.
- New `MtpFilterTranslator` maps them into the existing `--filter` expression: same-kind values OR together, different kinds AND together, `not-` variants exclude (AND-ed negations), structural chars escaped, `*` left intact.
- `--filter` and the simple filters are **mutually exclusive** (validation error if both supplied, mirroring xUnit).
- Malformed `--filter-trait` values (missing `=` separator or empty trait name) are rejected with a clear validation error rather than being silently reinterpreted.
- The translated expression flows through the unchanged delivery channels (`DEVICE_RUNNERS_FILTER` env var / MSIX arg / WASM query string), including the Windows loose-MSIX launch path.

## Filter mapping

| MTP switch | Maps to |
|---|---|
| `--filter-class` | `ClassName=` |
| `--filter-method` | `FullyQualifiedName=` |
| `--filter-namespace` | `Namespace=` |
| `--filter-trait name=value` | `name=value` |
| `--filter-not-*` | negated (`!=`) variants |

## Tests

- New `MtpFilterTranslator` unit tests (per-kind OR, cross-kind AND, `not-` exclusion, wildcard pass-through, trait split, escaping, empty→null, trait validation).
- Extended env-var + validation tests (`DEVICE_RUNNERS_FILTER` built from simple filters, precedence, mutual-exclusion, malformed-trait rejection).
- New wildcard matching tests in `TestCaseFilterTests` (starts-with / ends-with / contains / mid-string, multi-segment, `!=` negation, trait values, case-insensitivity, exact-match parity).
- **CLI: 96 passed · VisualRunners: 223 passed.**

## Docs

- `using-devicerunners-cli.md`: new Filtering Tests section (raw `--filter` + the 8 simple switches, combine rules).
- `using-dotnet-test.md`: `*` wildcard note + examples.
- `xunit-v3-support.md`: MTP-parity table and a `--filter-query` explainer (explained only — **not** implemented).

## Scoping note

Android delivers filters via build-time MSBuild env-baking, so `device-runners android test` (which launches an already-installed app) doesn't re-apply these switches — Android filtering goes through the `dotnet test --filter` path (which now has wildcards). This is documented. Wiring the simple switches into the MSBuild/Android path can be a follow-up if full parity there is desired.

## Review feedback addressed

Two-model review (GPT-5.5 + Opus 4.8). Fixes in `340c47d`:
- **ReDoS hardening** — wildcard regex now uses `RegexOptions.NonBacktracking` (linear-time, no catastrophic backtracking).
- **Windows loose-MSIX path** — now forwards the effective (translated) filter, so the simple switches aren't dropped on that launch path.
- **Malformed trait validation** — a `--filter-trait` entry with no `=` or an empty name now fails validation instead of being silently treated as a `FullyQualifiedName` filter.