### PR TITLE
Avoid binding diagnostic warnings on Apple

### DIFF
--- a/src/DeviceRunners.VisualRunners.Maui/App/Pages/DiagnosticsPage.xaml
+++ b/src/DeviceRunners.VisualRunners.Maui/App/Pages/DiagnosticsPage.xaml
@@ -15,7 +15,7 @@
 
         <Label Text="Diagnostic Messages:" FontAttributes="Bold" />
 
-        <Editor Text="{Binding MessagesString}" IsReadOnly="True" AutomationId="DiagnosticsMessagesEditor" Grid.Row="1" />
+        <Editor Text="{Binding MessagesString, Mode=OneWay}" IsReadOnly="True" AutomationId="DiagnosticsMessagesEditor" Grid.Row="1" />
 
     </Grid>
 

--- a/src/DeviceRunners.VisualRunners.Maui/App/Pages/HomePage.xaml
+++ b/src/DeviceRunners.VisualRunners.Maui/App/Pages/HomePage.xaml
@@ -58,7 +58,7 @@
         <Label Text="Diagnostic Messages:" FontAttributes="Bold"
                Grid.Row="2" Grid.ColumnSpan="2" />
 
-        <Editor Text="{Binding Diagnostics.MessagesString}" IsReadOnly="True"
+        <Editor Text="{Binding Diagnostics.MessagesString, Mode=OneWay}" IsReadOnly="True"
                 Grid.Row="3" Grid.ColumnSpan="2" />
 
         <!-- busy indicator -->


### PR DESCRIPTION
* Bind read-only Editors with Mode=OneWay