### PR TITLE
Bump NuGet dependencies to latest versions

### DIFF
--- a/.azure/templates/test-dotnet-test-windows.yml
+++ b/.azure/templates/test-dotnet-test-windows.yml
@@ -30,14 +30,29 @@ jobs:
         displayName: 'Restore test project (populates NuGet cache for WinAppSDK)'
       - pwsh: |
           $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'win10-arm64' } else { 'win10-x64' }
-          $wasdkDir = Get-ChildItem "$env:USERPROFILE/.nuget/packages/microsoft.windowsappsdk" -Directory |
-            Sort-Object Name -Descending | Select-Object -First 1
-          if (-not $wasdkDir) { Write-Error "WindowsAppSDK NuGet package not found"; exit 1 }
-          $msixDir = Join-Path $wasdkDir.FullName "tools/MSIX/$arch"
-          Write-Host "Installing WinAppSDK runtime from: $msixDir"
-          Get-ChildItem "$msixDir/*.msix" | ForEach-Object {
-            Write-Host "  Installing: $($_.Name)"
-            Add-AppxPackage -Path $_.FullName -ErrorAction SilentlyContinue
+          $packagesRoot = Join-Path $env:USERPROFILE ".nuget/packages"
+          # WindowsAppSDK 1.8+ moved the runtime MSIX packages out of the
+          # microsoft.windowsappsdk metapackage into microsoft.windowsappsdk.runtime.
+          $msixFiles = @()
+          foreach ($pkg in @('microsoft.windowsappsdk.runtime', 'microsoft.windowsappsdk')) {
+            $pkgRoot = Join-Path $packagesRoot $pkg
+            if (-not (Test-Path $pkgRoot)) { continue }
+            $versionDirs = Get-ChildItem $pkgRoot -Directory | Sort-Object Name -Descending
+            foreach ($versionDir in $versionDirs) {
+              $msixDir = Join-Path $versionDir.FullName "tools/MSIX/$arch"
+              $found = Get-ChildItem "$msixDir/*.msix" -ErrorAction SilentlyContinue
+              if ($found) {
+                Write-Host "Installing WinAppSDK runtime from: $msixDir"
+                $msixFiles = $found
+                break
+              }
+            }
+            if ($msixFiles.Count -gt 0) { break }
+          }
+          if ($msixFiles.Count -eq 0) { Write-Error "WindowsAppSDK runtime MSIX packages not found"; exit 1 }
+          foreach ($msix in $msixFiles) {
+            Write-Host "  Installing: $($msix.Name)"
+            Add-AppxPackage -Path $msix.FullName -ErrorAction SilentlyContinue
           }
         displayName: 'Install Windows App Runtime framework'
       - pwsh: |

--- a/.azure/templates/test-tcp-windows-loose.yml
+++ b/.azure/templates/test-tcp-windows-loose.yml
@@ -42,14 +42,29 @@ jobs:
         displayName: 'Build App (loose layout)'
       - pwsh: |
           $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'win10-arm64' } else { 'win10-x64' }
-          $wasdkDir = Get-ChildItem "$env:USERPROFILE/.nuget/packages/microsoft.windowsappsdk" -Directory |
-            Sort-Object Name -Descending | Select-Object -First 1
-          if (-not $wasdkDir) { Write-Error "WindowsAppSDK NuGet package not found"; exit 1 }
-          $msixDir = Join-Path $wasdkDir.FullName "tools/MSIX/$arch"
-          Write-Host "Installing WinAppSDK runtime from: $msixDir"
-          Get-ChildItem "$msixDir/*.msix" | ForEach-Object {
-            Write-Host "  Installing: $($_.Name)"
-            Add-AppxPackage -Path $_.FullName -ErrorAction SilentlyContinue
+          $packagesRoot = Join-Path $env:USERPROFILE ".nuget/packages"
+          # WindowsAppSDK 1.8+ moved the runtime MSIX packages out of the
+          # microsoft.windowsappsdk metapackage into microsoft.windowsappsdk.runtime.
+          $msixFiles = @()
+          foreach ($pkg in @('microsoft.windowsappsdk.runtime', 'microsoft.windowsappsdk')) {
+            $pkgRoot = Join-Path $packagesRoot $pkg
+            if (-not (Test-Path $pkgRoot)) { continue }
+            $versionDirs = Get-ChildItem $pkgRoot -Directory | Sort-Object Name -Descending
+            foreach ($versionDir in $versionDirs) {
+              $msixDir = Join-Path $versionDir.FullName "tools/MSIX/$arch"
+              $found = Get-ChildItem "$msixDir/*.msix" -ErrorAction SilentlyContinue
+              if ($found) {
+                Write-Host "Installing WinAppSDK runtime from: $msixDir"
+                $msixFiles = $found
+                break
+              }
+            }
+            if ($msixFiles.Count -gt 0) { break }
+          }
+          if ($msixFiles.Count -eq 0) { Write-Error "WindowsAppSDK runtime MSIX packages not found"; exit 1 }
+          foreach ($msix in $msixFiles) {
+            Write-Host "  Installing: $($msix.Name)"
+            Add-AppxPackage -Path $msix.FullName -ErrorAction SilentlyContinue
           }
         displayName: 'Install Windows App Runtime framework'
       - pwsh: |

--- a/.azure/templates/test-tcp-windows.yml
+++ b/.azure/templates/test-tcp-windows.yml
@@ -43,8 +43,15 @@ jobs:
           device-runners windows cert uninstall --fingerprint $fingerprint
         displayName: 'Publish App'
       - pwsh: |
-          $msix = (Get-ChildItem -Recurse -Filter "*.msix" -Path "artifacts" | Select-Object -First 1).FullName
-          if (-not $msix) { Write-Error "No .msix file found in artifacts"; exit 1 }
+          $projectDir = Split-Path -Parent "sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj"
+          # WindowsAppSDK 1.8+ emits the packaged .msix under the project's AppPackages
+          # folder rather than under artifacts, so search both locations. Exclude the
+          # framework dependency packages so we select the app package itself.
+          $searchRoots = @('artifacts', (Join-Path $projectDir 'AppPackages')) | Where-Object { Test-Path $_ }
+          $msix = Get-ChildItem -Recurse -Filter "*.msix" -Path $searchRoots -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -notmatch '[\\/]Dependencies[\\/]' -and $_.Name -notlike 'Microsoft.WindowsAppRuntime*' } |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $msix) { Write-Error "No .msix file found"; exit 1 }
           device-runners windows test --app $msix --results-directory artifacts/test-results
         displayName: 'Run Tests'
       - pwsh: |

--- a/.azure/templates/test-xharness-windows.yml
+++ b/.azure/templates/test-xharness-windows.yml
@@ -38,8 +38,15 @@ jobs:
           ./scripts/Remove-Certificate.ps1 -CertificateFingerprint $fingerprint
         displayName: 'Publish App'
       - pwsh: |
-          $msix = (Get-ChildItem -Recurse -Filter "*.msix" -Path "artifacts" | Select-Object -First 1).FullName
-          if (-not $msix) { Write-Error "No .msix file found in artifacts"; exit 1 }
+          $projectDir = Split-Path -Parent "sample/test/DeviceTestingKitApp.DeviceTests/DeviceTestingKitApp.DeviceTests.csproj"
+          # WindowsAppSDK 1.8+ emits the packaged .msix under the project's AppPackages
+          # folder rather than under artifacts, so search both locations. Exclude the
+          # framework dependency packages so we select the app package itself.
+          $searchRoots = @('artifacts', (Join-Path $projectDir 'AppPackages')) | Where-Object { Test-Path $_ }
+          $msix = Get-ChildItem -Recurse -Filter "*.msix" -Path $searchRoots -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -notmatch '[\\/]Dependencies[\\/]' -and $_.Name -notlike 'Microsoft.WindowsAppRuntime*' } |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $msix) { Write-Error "No .msix file found"; exit 1 }
           ./scripts/Start-Tests.ps1 `
             -App $msix `
             -OutputDirectory artifacts/test-results `

--- a/.github/workflows/test-dotnet-test-windows/action.yml
+++ b/.github/workflows/test-dotnet-test-windows/action.yml
@@ -35,14 +35,29 @@ runs:
       shell: pwsh
       run: |
         $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'win10-arm64' } else { 'win10-x64' }
-        $wasdkDir = Get-ChildItem "$env:USERPROFILE/.nuget/packages/microsoft.windowsappsdk" -Directory |
-          Sort-Object Name -Descending | Select-Object -First 1
-        if (-not $wasdkDir) { Write-Error "WindowsAppSDK NuGet package not found"; exit 1 }
-        $msixDir = Join-Path $wasdkDir.FullName "tools/MSIX/$arch"
-        Write-Host "Installing WinAppSDK runtime from: $msixDir"
-        Get-ChildItem "$msixDir/*.msix" | ForEach-Object {
-          Write-Host "  Installing: $($_.Name)"
-          Add-AppxPackage -Path $_.FullName -ErrorAction SilentlyContinue
+        $packagesRoot = Join-Path $env:USERPROFILE ".nuget/packages"
+        # WindowsAppSDK 1.8+ moved the runtime MSIX packages out of the
+        # microsoft.windowsappsdk metapackage into microsoft.windowsappsdk.runtime.
+        $msixFiles = @()
+        foreach ($pkg in @('microsoft.windowsappsdk.runtime', 'microsoft.windowsappsdk')) {
+          $pkgRoot = Join-Path $packagesRoot $pkg
+          if (-not (Test-Path $pkgRoot)) { continue }
+          $versionDirs = Get-ChildItem $pkgRoot -Directory | Sort-Object Name -Descending
+          foreach ($versionDir in $versionDirs) {
+            $msixDir = Join-Path $versionDir.FullName "tools/MSIX/$arch"
+            $found = Get-ChildItem "$msixDir/*.msix" -ErrorAction SilentlyContinue
+            if ($found) {
+              Write-Host "Installing WinAppSDK runtime from: $msixDir"
+              $msixFiles = $found
+              break
+            }
+          }
+          if ($msixFiles.Count -gt 0) { break }
+        }
+        if ($msixFiles.Count -eq 0) { Write-Error "WindowsAppSDK runtime MSIX packages not found"; exit 1 }
+        foreach ($msix in $msixFiles) {
+          Write-Host "  Installing: $($msix.Name)"
+          Add-AppxPackage -Path $msix.FullName -ErrorAction SilentlyContinue
         }
     - name: Run Tests
       shell: pwsh

--- a/.github/workflows/test-tcp-windows-loose/action.yml
+++ b/.github/workflows/test-tcp-windows-loose/action.yml
@@ -43,14 +43,29 @@ runs:
       shell: pwsh
       run: |
         $arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'win10-arm64' } else { 'win10-x64' }
-        $wasdkDir = Get-ChildItem "$env:USERPROFILE/.nuget/packages/microsoft.windowsappsdk" -Directory |
-          Sort-Object Name -Descending | Select-Object -First 1
-        if (-not $wasdkDir) { Write-Error "WindowsAppSDK NuGet package not found"; exit 1 }
-        $msixDir = Join-Path $wasdkDir.FullName "tools/MSIX/$arch"
-        Write-Host "Installing WinAppSDK runtime from: $msixDir"
-        Get-ChildItem "$msixDir/*.msix" | ForEach-Object {
-          Write-Host "  Installing: $($_.Name)"
-          Add-AppxPackage -Path $_.FullName -ErrorAction SilentlyContinue
+        $packagesRoot = Join-Path $env:USERPROFILE ".nuget/packages"
+        # WindowsAppSDK 1.8+ moved the runtime MSIX packages out of the
+        # microsoft.windowsappsdk metapackage into microsoft.windowsappsdk.runtime.
+        $msixFiles = @()
+        foreach ($pkg in @('microsoft.windowsappsdk.runtime', 'microsoft.windowsappsdk')) {
+          $pkgRoot = Join-Path $packagesRoot $pkg
+          if (-not (Test-Path $pkgRoot)) { continue }
+          $versionDirs = Get-ChildItem $pkgRoot -Directory | Sort-Object Name -Descending
+          foreach ($versionDir in $versionDirs) {
+            $msixDir = Join-Path $versionDir.FullName "tools/MSIX/$arch"
+            $found = Get-ChildItem "$msixDir/*.msix" -ErrorAction SilentlyContinue
+            if ($found) {
+              Write-Host "Installing WinAppSDK runtime from: $msixDir"
+              $msixFiles = $found
+              break
+            }
+          }
+          if ($msixFiles.Count -gt 0) { break }
+        }
+        if ($msixFiles.Count -eq 0) { Write-Error "WindowsAppSDK runtime MSIX packages not found"; exit 1 }
+        foreach ($msix in $msixFiles) {
+          Write-Host "  Installing: $($msix.Name)"
+          Add-AppxPackage -Path $msix.FullName -ErrorAction SilentlyContinue
         }
     - name: Run Tests with Loose MSIX Layout
       shell: pwsh

--- a/.github/workflows/test-tcp-windows/action.yml
+++ b/.github/workflows/test-tcp-windows/action.yml
@@ -43,9 +43,15 @@ runs:
     - name: Run Tests
       shell: pwsh
       run: |
-        $msix = (Get-ChildItem -Recurse -Filter "*.msix" -Path "artifacts" | Select-Object -First 1).FullName
-        if (-not $msix) { Write-Error "No .msix file found in artifacts"; exit 1 }
-        device-runners windows test --app $msix --results-directory artifacts/test-results --logger trx
+        $projectDir = Split-Path -Parent "${{ inputs.test-project }}"
+        # WindowsAppSDK 1.8+ emits the packaged .msix under the project's AppPackages
+        # folder rather than under artifacts, so search both locations. Exclude the
+        # framework dependency packages so we select the app package itself.
+        $searchRoots = @('artifacts', (Join-Path $projectDir 'AppPackages')) | Where-Object { Test-Path $_ }
+        $msix = Get-ChildItem -Recurse -Filter "*.msix" -Path $searchRoots -ErrorAction SilentlyContinue |
+          Where-Object { $_.FullName -notmatch '[\\/]Dependencies[\\/]' -and $_.Name -notlike 'Microsoft.WindowsAppRuntime*' } |
+          Select-Object -First 1 -ExpandProperty FullName
+        if (-not $msix) { Write-Error "No .msix file found"; exit 1 }
     - name: Clean up build artifacts before upload
       if: always()
       shell: pwsh

--- a/.github/workflows/test-tcp-windows/action.yml
+++ b/.github/workflows/test-tcp-windows/action.yml
@@ -52,6 +52,7 @@ runs:
           Where-Object { $_.FullName -notmatch '[\\/]Dependencies[\\/]' -and $_.Name -notlike 'Microsoft.WindowsAppRuntime*' } |
           Select-Object -First 1 -ExpandProperty FullName
         if (-not $msix) { Write-Error "No .msix file found"; exit 1 }
+        device-runners windows test --app $msix --results-directory artifacts/test-results --logger trx
     - name: Clean up build artifacts before upload
       if: always()
       shell: pwsh

--- a/.github/workflows/test-xharness-windows/action.yml
+++ b/.github/workflows/test-xharness-windows/action.yml
@@ -37,8 +37,15 @@ runs:
     - name: Run Tests
       shell: powershell
       run: |
-        $msix = (Get-ChildItem -Recurse -Filter "*.msix" -Path "artifacts" | Select-Object -First 1).FullName
-        if (-not $msix) { Write-Error "No .msix file found in artifacts"; exit 1 }
+        $projectDir = Split-Path -Parent "${{ inputs.test-project }}"
+        # WindowsAppSDK 1.8+ emits the packaged .msix under the project's AppPackages
+        # folder rather than under artifacts, so search both locations. Exclude the
+        # framework dependency packages so we select the app package itself.
+        $searchRoots = @('artifacts', (Join-Path $projectDir 'AppPackages')) | Where-Object { Test-Path $_ }
+        $msix = Get-ChildItem -Recurse -Filter "*.msix" -Path $searchRoots -ErrorAction SilentlyContinue |
+          Where-Object { $_.FullName -notmatch '[\\/]Dependencies[\\/]' -and $_.Name -notlike 'Microsoft.WindowsAppRuntime*' } |
+          Select-Object -First 1 -ExpandProperty FullName
+        if (-not $msix) { Write-Error "No .msix file found"; exit 1 }
         ./scripts/Start-Tests.ps1 `
           -App $msix `
           -OutputDirectory artifacts/test-results `

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+    <PackageReference Update="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
   </ItemGroup>
 
   <Target Name="AddApplePlatformsFolder" BeforeTargets="_MauiRemovePlatformCompileItems">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,25 +2,25 @@
   <ItemGroup>
     <PackageVersion Include="AndroidSdk" Version="0.35.1" />
     <PackageVersion Include="AppleDev" Version="0.8.10" />
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageVersion Include="Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit" Version="11.0.0-prerelease.26259.3" />
-    <PackageVersion Include="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26259.3" />
-    <PackageVersion Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="11.0.0-prerelease.26259.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.20" />
-    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.20" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageVersion Include="Microsoft.DotNet.XHarness.DefaultAndroidEntryPoint.Xunit" Version="11.0.0-prerelease.26360.1" />
+    <PackageVersion Include="Microsoft.DotNet.XHarness.TestRunners.Common" Version="11.0.0-prerelease.26360.1" />
+    <PackageVersion Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="11.0.0-prerelease.26360.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.80" />
+    <PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="10.0.80" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NUnit" Version="4.5.1" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.3.1" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.1" />
-    <PackageVersion Include="Spectre.Console.Testing" Version="0.54.0" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.14.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.17" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.WinApp" Version="0.4.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
+    <PackageVersion Include="Spectre.Console.Testing" Version="0.57.2" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.utility" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/src/DeviceRunners.Cli/Commands/Android/AppInstallCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Android/AppInstallCommand.cs
@@ -19,7 +19,7 @@ public class AndroidAppInstallCommand(IAnsiConsole console) : BaseCommand<Androi
         public string? Device { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/DeviceRunners.Cli/Commands/Android/AppLaunchCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Android/AppLaunchCommand.cs
@@ -27,7 +27,7 @@ public class AndroidAppLaunchCommand(IAnsiConsole console) : BaseCommand<Android
         public string? Device { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/DeviceRunners.Cli/Commands/Android/AppUninstallCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Android/AppUninstallCommand.cs
@@ -23,7 +23,7 @@ public class AndroidAppUninstallCommand(IAnsiConsole console) : BaseCommand<Andr
         public string? Device { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/DeviceRunners.Cli/Commands/BaseAsyncCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/BaseAsyncCommand.cs
@@ -20,7 +20,7 @@ public abstract class BaseAsyncCommand<TSettings>(IAnsiConsole console) : Comman
         public OutputFormat OutputFormat { get; set; } = OutputFormat.Default;
     }
 
-    public override int Execute(CommandContext context, TSettings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, TSettings settings, CancellationToken cancellationToken)
     {
         return ExecuteAsync(context, settings).GetAwaiter().GetResult();
     }

--- a/src/DeviceRunners.Cli/Commands/BaseTestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/BaseTestCommand.cs
@@ -55,7 +55,7 @@ public abstract class BaseTestCommand<TSettings>(IAnsiConsole console) : BaseCom
 		public string? Filter { get; set; }
 	}
 
-	public override int Execute(CommandContext context, TSettings settings, CancellationToken cancellationToken)
+	protected override int Execute(CommandContext context, TSettings settings, CancellationToken cancellationToken)
 	{
 		return ExecuteAsync(context, settings).GetAwaiter().GetResult();
 	}

--- a/src/DeviceRunners.Cli/Commands/MacOS/AppInstallCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/MacOS/AppInstallCommand.cs
@@ -15,7 +15,7 @@ public class MacOSAppInstallCommand(IAnsiConsole console) : BaseCommand<MacOSApp
         public required string App { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/DeviceRunners.Cli/Commands/MacOS/AppLaunchCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/MacOS/AppLaunchCommand.cs
@@ -19,7 +19,7 @@ public class MacOSAppLaunchCommand(IAnsiConsole console) : BaseCommand<MacOSAppL
         public string? Arguments { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/DeviceRunners.Cli/Commands/MacOS/AppUninstallCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/MacOS/AppUninstallCommand.cs
@@ -15,7 +15,7 @@ public class MacOSAppUninstallCommand(IAnsiConsole console) : BaseCommand<MacOSA
         public required string App { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/DeviceRunners.Cli/Commands/PortListenerCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/PortListenerCommand.cs
@@ -32,7 +32,7 @@ public class PortListenerCommand(IAnsiConsole console) : BaseCommand<PortListene
         public int? DataTimeout { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         return ExecuteAsync(context, settings).GetAwaiter().GetResult();
     }

--- a/src/DeviceRunners.Cli/Commands/Windows/AppInstallCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Windows/AppInstallCommand.cs
@@ -19,7 +19,7 @@ public class WindowsAppInstallCommand(IAnsiConsole console) : BaseCommand<Window
         public string? Certificate { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/DeviceRunners.Cli/Commands/Windows/AppLaunchCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Windows/AppLaunchCommand.cs
@@ -23,7 +23,7 @@ public class WindowsAppLaunchCommand(IAnsiConsole console) : BaseCommand<Windows
         public string? Arguments { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/DeviceRunners.Cli/Commands/Windows/AppUninstallCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Windows/AppUninstallCommand.cs
@@ -23,7 +23,7 @@ public class WindowsAppUninstallCommand(IAnsiConsole console) : BaseCommand<Wind
         public string? CertificateFingerprint { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/DeviceRunners.Cli/Commands/Windows/CertificateCreateCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Windows/CertificateCreateCommand.cs
@@ -25,7 +25,7 @@ public class WindowCertificateCreateCommand(IAnsiConsole console) : BaseCommand<
         public string? Project { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {

--- a/src/DeviceRunners.Cli/Commands/Windows/CertificateRemoveCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Windows/CertificateRemoveCommand.cs
@@ -15,7 +15,7 @@ public class WindowCertificateRemoveCommand(IAnsiConsole console) : BaseCommand<
         public required string Fingerprint { get; set; }
     }
 
-    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         try
         {


### PR DESCRIPTION
## Summary

Bumps centrally-managed NuGet dependencies (`Directory.Packages.props` + `Directory.Build.targets`) to their latest available versions.

| Package | From → To |
|---|---|
| CommunityToolkit.Mvvm | 8.4.0 → 8.4.2 |
| Microsoft.DotNet.XHarness.* (×3) | …26259.3 → …26360.1 |
| Microsoft.Extensions.Logging.* (×3) | 10.0.3 → 10.0.9 |
| Microsoft.Maui.Controls (+Compatibility) | 10.0.20 → 10.0.80 |
| Microsoft.NET.Test.Sdk | 18.3.0 → 18.7.0 |
| NUnit | 4.5.1 → 4.6.1 |
| NUnit.Analyzers | 4.12.0 → 4.14.0 |
| NUnit3TestAdapter | 6.1.0 → 6.2.0 |
| Microsoft.AspNetCore.Components.WebAssembly | 9.0.5 → 9.0.17 |
| Microsoft.Windows.SDK.BuildTools.WinApp | 0.3.1 → 0.4.0 |
| Spectre.Console.Cli | 0.53.1 → 0.55.0 |
| Spectre.Console.Testing | 0.54.0 → 0.57.2 |
| coverlet.collector | 8.0.0 → 10.0.1 |
| Microsoft.Windows.SDK.BuildTools | 10.0.22621.756 → 10.0.28000.2270 |

**WebAssembly** stays on the 9.0.x line (9.0.17) because several projects still target `net9.0`; 10.0.x requires net10.

## Code change

Spectre.Console.Cli 0.55.0 changed `Command<T>.Execute(..., CancellationToken)` from `public` to `protected`. Updated the 14 `Execute` overrides in `DeviceRunners.Cli` to match the new access modifier. No callers invoke `Execute` directly, so behavior is unchanged.

## Held back (only prereleases are newer)

AndroidSdk, AppleDev, NSubstitute (6.0-rc), xunit 2.9.3, xunit.runner.visualstudio 3.1.5, xunit.v3 3.2.2 (4.0-pre). The MAUI `net9` override remains at 9.0.120 (latest 9.0.x).

## Local verification

- ✅ Full-solution restore (`DeviceRunners.slnx`) — all 34 projects resolve across every TFM
- ✅ `dotnet test test/Tests.slnx` — Cli 70, VisualRunners.Xunit3 74, VisualRunners 207
- ✅ Clean builds (warnings-as-errors): MauiLibrary android (MAUI 10.0.80), XHarness.Xunit android, Blazor net9 (WASM 9.0.17)
- The NUnit sample's `FailingTest` is an intentional demo failure (pre-existing, unrelated)