### PR TITLE
Allow extra switches to be passed to the WASM browser

### DIFF
--- a/docs/articles/cli-device-runner-for-wasm-using-devicerunners-cli.md
+++ b/docs/articles/cli-device-runner-for-wasm-using-devicerunners-cli.md
@@ -67,9 +67,43 @@ device-runners wasm test \
 | `--timeout` | `300` | Test execution timeout in seconds |
 | `--headed` | `false` | Run browser in visible mode (useful for debugging) |
 | `--server-port` | `0` (auto) | HTTP port for the local web server |
+| `--browser-args` | *(none)* | Extra switches for the browser, quoted as in a shell. Repeatable. Use the `=` form: `--browser-args=--enable-unsafe-webgpu` |
 | `--output` | `default` | CLI output format: `default`, `json`, `xml`, or `text` |
 
 The test command also generates a `browser-console.log` file in the results directory containing all browser console output, similar to `logcat.txt` on Android or `ios-device-log.txt` on iOS.
+
+#### Passing switches to the browser
+
+`--browser-args` takes a command-line fragment and splits it using shell quoting rules, so a
+switch whose value contains a space just needs quotes:
+
+```bash
+device-runners wasm test --app "$wwwroot" \
+  --browser-args='--enable-unsafe-webgpu "--host-resolver-rules=MAP a.test 127.0.0.1"'
+```
+
+It is repeatable, so this is equivalent:
+
+```bash
+device-runners wasm test --app "$wwwroot" \
+  --browser-args=--enable-unsafe-swiftshader \
+  --browser-args=--enable-unsafe-webgpu
+```
+
+Use the `=` form. Spectre.Console treats a following token that starts with `-` as another
+option, so `--browser-args --enable-unsafe-webgpu` is rejected.
+
+The switches are appended after everything the CLI sets itself, so they win for the switches
+where Chrome keeps only the last occurrence. The full command line is printed as
+`Browser args:` at the start of every run.
+
+> [!NOTE]
+> This configures the **browser**, not the app under test. The app is configured through the
+> runner's own query-string parameters (`?device-runners-autorun=1`), the WASM equivalent of
+> the `DEVICE_RUNNERS_*` environment variables used on the other platforms.
+
+This is a passthrough — the CLI adds no graphics-related switches of its own. See
+[WebGL and WebGPU](#webgl-and-webgpu) below for what those APIs need on a CI agent.
 
 ### `wasm serve`
 
@@ -102,6 +136,37 @@ If the app fails to boot, check the Blazor WebAssembly publish output to ensure 
 ### Console output is empty
 
 Ensure the test app calls `AddConsoleResultChannel()` in its `Program.cs`. When using `UseVisualTestRunner` on `WebAssemblyHostBuilder`, the CLI configuration is automatically injected — when the browser navigates to `?device-runners-autorun=1`, the `EventStreamFormatter` console output is enabled.
+
+### WebGL and WebGPU
+
+A browser on a machine with no usable GPU — most CI agents — reports WebGL as unavailable
+(`canvas.getContext("webgl")` returns `null`) and WebGPU as adapter-less
+(`navigator.gpu.requestAdapter()` resolves to `null`). Headless mode is not the cause: a
+visible browser behaves the same. The cause is the missing GPU.
+
+Chrome can fall back to the SwiftShader software renderer, but only when asked. Measured with
+Chrome 150 on GPU-less GitHub-hosted runners:
+
+| Host | For WebGL | For WebGPU |
+| --- | --- | --- |
+| Linux | *(works already)* | `--enable-unsafe-webgpu` |
+| macOS | `--enable-unsafe-swiftshader` | `--enable-unsafe-webgpu` |
+| Windows | *(works already, via D3D11 WARP)* | `--enable-unsafe-webgpu --use-webgpu-adapter=swiftshader` |
+
+Notes:
+
+- On **Windows**, `--enable-unsafe-swiftshader` moves ANGLE onto the SwiftShader Vulkan
+  device, after which Dawn cannot enumerate any WebGPU adapter. Don't combine it with the
+  WebGPU switches there.
+- `--use-webgpu-adapter=swiftshader` forces software rendering even when a real GPU is
+  present, so apply it on CI rather than everywhere.
+- Avoid passing `--disable-gpu`. On Windows it removes the fallback WebGPU needs, and
+  `requestAdapter()` returns `null` even with `--use-webgpu-adapter=swiftshader`.
+- `navigator.gpu` only exists in a [secure context]. The built-in server uses
+  `http://127.0.0.1`, which qualifies; a plain `http://` LAN address does not, and WebGPU
+  silently disappears there.
+
+[secure context]: https://developer.mozilla.org/docs/Web/Security/Secure_Contexts
 
 ### Debugging with headed mode
 

--- a/docs/articles/dotnet-test-wasm.md
+++ b/docs/articles/dotnet-test-wasm.md
@@ -67,6 +67,41 @@ To change the test execution timeout, set `DeviceRunnersWasmTimeout` (default: 3
 dotnet test MyApp.BrowserTests.csproj -p:DeviceRunnersWasmTimeout=600
 ```
 
+### Passing switches to the browser
+
+`DeviceRunnersWasmBrowserArgs` sets extra switches on the browser the CLI launches:
+
+```bash
+dotnet test MyApp.BrowserTests.csproj -p:DeviceRunnersWasmBrowserArgs=--enable-unsafe-webgpu
+```
+
+```xml
+<PropertyGroup>
+  <DeviceRunnersWasmBrowserArgs>--enable-unsafe-swiftshader --enable-unsafe-webgpu</DeviceRunnersWasmBrowserArgs>
+</PropertyGroup>
+```
+
+The value is a command-line fragment, not an MSBuild list. Separate switches with spaces and
+quote any value that contains one, exactly as you would in a shell:
+
+```xml
+<PropertyGroup>
+  <DeviceRunnersWasmBrowserArgs>--enable-unsafe-webgpu "--host-resolver-rules=MAP a.test 127.0.0.1"</DeviceRunnersWasmBrowserArgs>
+</PropertyGroup>
+```
+
+The switches are appended after everything the CLI sets itself, so they win for the switches
+where Chrome keeps only the last occurrence. The full command line is printed as `Browser
+args:` at the start of every run.
+
+> [!NOTE]
+> This configures the **browser**, not the app under test. The app is configured through the
+> runner's own query-string parameters (`?device-runners-autorun=1`), which is the WASM
+> equivalent of the `DEVICE_RUNNERS_*` environment variables used on the other platforms.
+
+This is a passthrough — the CLI adds no graphics-related switches of its own. See
+[WebGL and WebGPU](#webgl-and-webgpu) for the switches those APIs need on a CI agent.
+
 ## Troubleshooting
 
 ### Chrome not found
@@ -76,6 +111,44 @@ The CLI searches for Chrome/Chromium in standard installation paths. If your Chr
 ### Tests hang or timeout
 
 If the app fails to boot, check the Blazor WebAssembly publish output to ensure the `wwwroot` directory contains `_framework/blazor.webassembly.js` and the app's DLLs. The default timeout is 300 seconds — use `--timeout` to increase it for large test suites.
+
+### WebGL and WebGPU
+
+A browser on a machine with no usable GPU — which describes most CI agents — reports WebGL as
+unavailable (`canvas.getContext("webgl")` returns `null`) and WebGPU as adapter-less
+(`navigator.gpu.requestAdapter()` resolves to `null`). This is not caused by headless mode: a
+visible browser behaves the same way. It is caused by there being no GPU.
+
+Chrome can fall back to the SwiftShader software renderer, but only when asked. Measured with
+Chrome 150 on GPU-less GitHub-hosted runners:
+
+| Host | For WebGL | For WebGPU |
+| --- | --- | --- |
+| Linux | *(works already)* | `--enable-unsafe-webgpu` |
+| macOS | `--enable-unsafe-swiftshader` | `--enable-unsafe-webgpu` |
+| Windows | *(works already, via D3D11 WARP)* | `--enable-unsafe-webgpu --use-webgpu-adapter=swiftshader` |
+
+For example, on a GPU-less Linux or macOS agent:
+
+```bash
+dotnet test MyApp.BrowserTests.csproj \
+  -p:DeviceRunnersWasmBrowserArgs="--enable-unsafe-swiftshader --enable-unsafe-webgpu"
+```
+
+Notes:
+
+- On **Windows**, `--enable-unsafe-swiftshader` moves ANGLE onto the SwiftShader Vulkan
+  device, after which Dawn cannot enumerate any WebGPU adapter. Don't combine it with the
+  WebGPU switches there.
+- `--use-webgpu-adapter=swiftshader` forces software rendering even when a real GPU is
+  present, so apply it on CI rather than in a checked-in property.
+- Avoid `--disable-gpu`. On Windows it removes the fallback WebGPU needs, and
+  `requestAdapter()` returns `null` even with `--use-webgpu-adapter=swiftshader`.
+- `navigator.gpu` only exists in a [secure context]. The built-in server uses
+  `http://127.0.0.1`, which qualifies; a plain `http://` LAN address does not, and WebGPU
+  silently disappears there.
+
+[secure context]: https://developer.mozilla.org/docs/Web/Security/Secure_Contexts
 
 ### Console output is empty
 

--- a/src/DeviceRunners.Cli/Commands/Wasm/WasmTestCommand.cs
+++ b/src/DeviceRunners.Cli/Commands/Wasm/WasmTestCommand.cs
@@ -26,6 +26,10 @@ public class WasmTestCommand(IAnsiConsole console) : BaseTestCommand<WasmTestCom
 		[CommandOption("--timeout")]
 		[DefaultValue(300)]
 		public int Timeout { get; set; } = 300;
+
+		[Description("Extra switches for the browser, quoted as they would be in a shell. Repeatable. Example: --browser-args \"--enable-unsafe-webgpu\"")]
+		[CommandOption("--browser-args")]
+		public string[] BrowserArgs { get; set; } = [];
 	}
 
 	protected override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
@@ -136,7 +140,17 @@ public class WasmTestCommand(IAnsiConsole console) : BaseTestCommand<WasmTestCom
 			var testUrl = $"{url}?device-runners-autorun=1";
 			if (!string.IsNullOrWhiteSpace(settings.Filter))
 				testUrl += $"&device-runners-filter={Uri.EscapeDataString(settings.Filter)}";
-			await browser.LaunchAsync(testUrl, headless: !settings.Headed);
+			// Each --browser-args value is a command-line fragment: the shell that
+			// launched us only stripped the outer quotes, so the inner grouping still
+			// has to be resolved. "--" is deliberately left alone — it is reserved for
+			// arguments aimed at the app under test rather than at the browser.
+			var browserArgs = settings.BrowserArgs.SelectMany(ArgumentTokenizer.Tokenize).ToList();
+
+			await browser.LaunchAsync(
+				testUrl,
+				headless: !settings.Headed,
+				extraArguments: browserArgs);
+			WriteConsoleOutput($"    Browser args: [grey]{Markup.Escape(string.Join(' ', browser.LaunchArguments))}[/]", settings);
 			WriteConsoleOutput($"    Browser launched, running tests...", settings);
 
 			// Wait for test completion or timeout

--- a/src/DeviceRunners.Cli/Services/ArgumentTokenizer.cs
+++ b/src/DeviceRunners.Cli/Services/ArgumentTokenizer.cs
@@ -1,0 +1,88 @@
+namespace DeviceRunners.Cli.Services;
+
+/// <summary>
+/// Splits a command-line fragment into individual arguments using the quoting rules a
+/// shell would apply.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Needed because options such as <c>--browser-args</c> receive a whole fragment as a
+/// single value — the shell that launched the CLI only stripped the outer quotes, so the
+/// inner grouping still has to be resolved.
+/// </para>
+/// <para>
+/// A backslash is only an escape character inside double quotes, so Windows paths can be
+/// written without doubling: <c>--user-data-dir=C:\temp\profile</c> means what it looks
+/// like. Inside double quotes, <c>\"</c> produces a literal quote.
+/// </para>
+/// </remarks>
+public static class ArgumentTokenizer
+{
+	public static IReadOnlyList<string> Tokenize(string? value)
+	{
+		var results = new List<string>();
+
+		if (string.IsNullOrWhiteSpace(value))
+			return results;
+
+		var current = new System.Text.StringBuilder();
+		var hasToken = false;
+		var quote = '\0';
+
+		for (var i = 0; i < value.Length; i++)
+		{
+			var c = value[i];
+
+			if (quote != '\0')
+			{
+				// Only double quotes support escaping, matching POSIX shells.
+				if (quote == '"' && c == '\\' && i + 1 < value.Length && value[i + 1] == '"')
+				{
+					current.Append('"');
+					i++;
+					continue;
+				}
+
+				if (c == quote)
+				{
+					quote = '\0';
+					continue;
+				}
+
+				current.Append(c);
+				continue;
+			}
+
+			if (c is '"' or '\'')
+			{
+				// An empty quoted section still produces an argument.
+				quote = c;
+				hasToken = true;
+				continue;
+			}
+
+			if (char.IsWhiteSpace(c))
+			{
+				if (hasToken)
+				{
+					results.Add(current.ToString());
+					current.Clear();
+					hasToken = false;
+				}
+
+				continue;
+			}
+
+			current.Append(c);
+			hasToken = true;
+		}
+
+		if (quote != '\0')
+			throw new FormatException($"Unbalanced {quote} quote in arguments: {value}");
+
+		if (hasToken)
+			results.Add(current.ToString());
+
+		return results;
+	}
+}

--- a/src/DeviceRunners.Cli/Services/BrowserService.cs
+++ b/src/DeviceRunners.Cli/Services/BrowserService.cs
@@ -22,7 +22,19 @@ public class BrowserService : IAsyncDisposable
 
 	public event EventHandler<string>? ConsoleMessageReceived;
 
-	public async Task LaunchAsync(string url, bool headless = true)
+	/// <summary>
+	/// The full argument list the browser was launched with. Useful for diagnostics.
+	/// </summary>
+	public IReadOnlyList<string> LaunchArguments { get; private set; } = [];
+
+	/// <param name="extraArguments">
+	/// Extra switches appended to the browser command line. They come last, so they win
+	/// for the switches where Chrome keeps only the final occurrence.
+	/// </param>
+	public async Task LaunchAsync(
+		string url,
+		bool headless = true,
+		IEnumerable<string>? extraArguments = null)
 	{
 		var chromePath = FindChrome();
 		if (chromePath is null)
@@ -33,37 +45,27 @@ public class BrowserService : IAsyncDisposable
 		_userDataDir = Path.Combine(Path.GetTempPath(), "device-runners-chrome-" + Guid.NewGuid().ToString("N")[..8]);
 		Directory.CreateDirectory(_userDataDir);
 
-		var args = new List<string>
+		var args = BuildLaunchArguments(_userDataDir, extraArguments, headless);
+
+		LaunchArguments = args;
+
+		var startInfo = new ProcessStartInfo
 		{
-			"--remote-debugging-port=0",
-			$"--user-data-dir={_userDataDir}",
-			"--no-first-run",
-			"--no-default-browser-check",
-			"--disable-extensions",
-			"--disable-background-networking",
-			"--disable-sync",
-			"--disable-translate",
-			"--metrics-recording-only",
-			"--safebrowsing-disable-auto-update",
+			FileName = chromePath,
+			RedirectStandardError = true,
+			RedirectStandardOutput = true,
+			UseShellExecute = false,
+			CreateNoWindow = true,
 		};
 
-		if (headless)
-			args.Add("--headless=new");
+		// ArgumentList quotes each entry as needed. Joining into a single Arguments
+		// string would split any argument that contains a space, and Chrome would treat
+		// the trailing part as an extra page to open ("Multiple targets are not
+		// supported in headless mode").
+		foreach (var arg in args)
+			startInfo.ArgumentList.Add(arg);
 
-		args.Add("about:blank");
-
-		_chromeProcess = new Process
-		{
-			StartInfo = new ProcessStartInfo
-			{
-				FileName = chromePath,
-				Arguments = string.Join(' ', args),
-				RedirectStandardError = true,
-				RedirectStandardOutput = true,
-				UseShellExecute = false,
-				CreateNoWindow = true,
-			}
-		};
+		_chromeProcess = new Process { StartInfo = startInfo };
 
 		_chromeProcess.Start();
 
@@ -86,6 +88,39 @@ public class BrowserService : IAsyncDisposable
 		// Navigate to the test URL
 		await SendCdpCommandAsync("Page.enable");
 		await SendCdpCommandAsync("Page.navigate", new CdpNavigateParams { Url = url });
+	}
+
+	/// <summary>
+	/// Assembles the browser command line. Caller arguments are placed after everything
+	/// the CLI sets itself, because Chrome keeps only the last occurrence of most
+	/// switches — so a caller can always override a default. The target URL stays last,
+	/// since a positional value after it would be treated as a second page to open.
+	/// </summary>
+	internal static List<string> BuildLaunchArguments(string userDataDir, IEnumerable<string>? extraArguments, bool headless)
+	{
+		var args = new List<string>
+		{
+			"--remote-debugging-port=0",
+			$"--user-data-dir={userDataDir}",
+			"--no-first-run",
+			"--no-default-browser-check",
+			"--disable-extensions",
+			"--disable-background-networking",
+			"--disable-sync",
+			"--disable-translate",
+			"--metrics-recording-only",
+			"--safebrowsing-disable-auto-update",
+		};
+
+		if (headless)
+			args.Add("--headless=new");
+
+		if (extraArguments is not null)
+			args.AddRange(extraArguments.Where(a => !string.IsNullOrWhiteSpace(a)));
+
+		args.Add("about:blank");
+
+		return args;
 	}
 
 	static async Task<string> ReadDevToolsUrlAsync(Process process, TimeSpan timeout)

--- a/src/DeviceRunners.Testing.Targets/build/DeviceRunners.Testing.Targets.props
+++ b/src/DeviceRunners.Testing.Targets/build/DeviceRunners.Testing.Targets.props
@@ -64,6 +64,18 @@
 
     <!-- WASM: test execution timeout in seconds (default 5 minutes). -->
     <DeviceRunnersWasmTimeout Condition="'$(DeviceRunnersWasmTimeout)' == ''">300</DeviceRunnersWasmTimeout>
+
+    <!--
+      WASM: extra switches for the browser the CLI launches. This is a command-line
+      fragment, not an MSBuild list: separate switches with spaces and quote any value
+      that contains one, exactly as you would in a shell.
+
+      Note this configures the browser, not the app under test. The app is configured
+      through the runner's own query-string parameters.
+
+      See docs/articles/dotnet-test-wasm.md for examples.
+    -->
+    <DeviceRunnersWasmBrowserArgs Condition="'$(DeviceRunnersWasmBrowserArgs)' == ''" />
   </PropertyGroup>
 
 

--- a/src/DeviceRunners.Testing.Targets/build/DeviceRunners.Testing.Targets.targets
+++ b/src/DeviceRunners.Testing.Targets/build/DeviceRunners.Testing.Targets.targets
@@ -249,8 +249,18 @@
     <Error Text="Published WASM output not found at '$(PublishDir)'. Make sure the project publishes successfully."
            Condition="!Exists('$(_DeviceRunnersWasmDir)')" />
     <PropertyGroup>
+      <!--
+        The property is a command-line fragment, passed through as a single value and
+        split by the CLI using shell quoting rules.
+
+        The "- -browser-args=value" form is required: Spectre.Console treats a following
+        token that starts with "-" as another option rather than as this option's value.
+        Inner quotes are escaped as \" so they survive both cmd.exe and /bin/sh.
+      -->
+      <_DeviceRunnersBrowserArgs Condition="'$(DeviceRunnersWasmBrowserArgs)' != ''"> --browser-args=&quot;$(DeviceRunnersWasmBrowserArgs.Replace('&quot;', '\&quot;'))&quot;</_DeviceRunnersBrowserArgs>
+
       <!-- WASM uses different CLI flags: no port/TCP, instead uses browser console capture -->
-      <_DeviceRunnersCliArgs>wasm test --app &quot;$(_DeviceRunnersWasmDir)&quot; --results-directory &quot;$(_DeviceRunnersResultsDir)&quot;$(_DeviceRunnersLoggerArg)$(_DeviceRunnersFilterArg) --timeout $(DeviceRunnersWasmTimeout)</_DeviceRunnersCliArgs>
+      <_DeviceRunnersCliArgs>wasm test --app &quot;$(_DeviceRunnersWasmDir)&quot; --results-directory &quot;$(_DeviceRunnersResultsDir)&quot;$(_DeviceRunnersLoggerArg)$(_DeviceRunnersFilterArg) --timeout $(DeviceRunnersWasmTimeout)$(_DeviceRunnersBrowserArgs)</_DeviceRunnersCliArgs>
     </PropertyGroup>
     <Message Importance="high" Text="DeviceRunners: running WASM browser tests from $(_DeviceRunnersWasmDir)" />
   </Target>

--- a/test/DeviceRunners.Cli.Tests/Services/ArgumentTokenizerTests.cs
+++ b/test/DeviceRunners.Cli.Tests/Services/ArgumentTokenizerTests.cs
@@ -1,0 +1,99 @@
+using DeviceRunners.Cli.Services;
+
+using Xunit;
+
+namespace DeviceRunners.Cli.Tests;
+
+public class ArgumentTokenizerTests
+{
+	[Fact]
+	public void EmptyInputProducesNoArguments()
+	{
+		Assert.Empty(ArgumentTokenizer.Tokenize(null));
+		Assert.Empty(ArgumentTokenizer.Tokenize(""));
+		Assert.Empty(ArgumentTokenizer.Tokenize("   "));
+	}
+
+	[Fact]
+	public void SplitsOnWhitespace()
+	{
+		var args = ArgumentTokenizer.Tokenize("--enable-unsafe-swiftshader --enable-unsafe-webgpu");
+
+		Assert.Equal(["--enable-unsafe-swiftshader", "--enable-unsafe-webgpu"], args);
+	}
+
+	[Fact]
+	public void CollapsesRepeatedWhitespace()
+	{
+		var args = ArgumentTokenizer.Tokenize("  --a \t  --b\n--c ");
+
+		Assert.Equal(["--a", "--b", "--c"], args);
+	}
+
+	[Fact]
+	public void DoubleQuotesGroupAValueContainingSpaces()
+	{
+		var args = ArgumentTokenizer.Tokenize("--a \"--host-resolver-rules=MAP a.test 127.0.0.1\" --b");
+
+		Assert.Equal(["--a", "--host-resolver-rules=MAP a.test 127.0.0.1", "--b"], args);
+	}
+
+	[Fact]
+	public void SingleQuotesGroupAValueContainingSpaces()
+	{
+		var args = ArgumentTokenizer.Tokenize("--a '--rules=MAP a.test 127.0.0.1'");
+
+		Assert.Equal(["--a", "--rules=MAP a.test 127.0.0.1"], args);
+	}
+
+	[Fact]
+	public void QuotesMayStartPartWayThroughAnArgument()
+	{
+		var args = ArgumentTokenizer.Tokenize("--host-resolver-rules=\"MAP a.test 127.0.0.1\"");
+
+		Assert.Equal(["--host-resolver-rules=MAP a.test 127.0.0.1"], args);
+	}
+
+	[Fact]
+	public void EscapedQuoteInsideDoubleQuotesIsLiteral()
+	{
+		var args = ArgumentTokenizer.Tokenize("--a=\"say \\\"hi\\\"\"");
+
+		Assert.Equal(["--a=say \"hi\""], args);
+	}
+
+	[Fact]
+	public void BackslashOutsideQuotesIsNotAnEscape()
+	{
+		// Windows paths must survive without doubling.
+		var args = ArgumentTokenizer.Tokenize(@"--user-data-dir=C:\temp\profile");
+
+		Assert.Equal([@"--user-data-dir=C:\temp\profile"], args);
+	}
+
+	[Fact]
+	public void BackslashInsideSingleQuotesIsNotAnEscape()
+	{
+		var args = ArgumentTokenizer.Tokenize(@"'--dir=C:\temp\a b'");
+
+		Assert.Equal([@"--dir=C:\temp\a b"], args);
+	}
+
+	[Fact]
+	public void AnEmptyQuotedSectionStillProducesAnArgument()
+	{
+		var args = ArgumentTokenizer.Tokenize("--a \"\" --b");
+
+		Assert.Equal(["--a", "", "--b"], args);
+	}
+
+	[Fact]
+	public void UnbalancedQuoteIsReported()
+	{
+		// Silently dropping the rest of the line would be far harder to diagnose than
+		// a message naming the offending value.
+		var ex = Assert.Throws<FormatException>(() => ArgumentTokenizer.Tokenize("--a \"--b"));
+
+		Assert.Contains("Unbalanced", ex.Message);
+	}
+}

--- a/test/DeviceRunners.Cli.Tests/Services/BrowserServiceTests.cs
+++ b/test/DeviceRunners.Cli.Tests/Services/BrowserServiceTests.cs
@@ -1,0 +1,92 @@
+using DeviceRunners.Cli.Services;
+
+using Xunit;
+
+namespace DeviceRunners.Cli.Tests;
+
+public class BrowserServiceTests
+{
+	// LaunchAsync starts a real browser, so exercise the argument assembly through the
+	// same helper it uses rather than launching Chrome from a unit test.
+	static List<string> BuildArgs(IEnumerable<string>? extra, bool headless = true) =>
+		BrowserService.BuildLaunchArguments("/tmp/profile", extra, headless);
+
+	[Fact]
+	public void NoExtraArgumentsKeepsTheBaseSwitchesOnly()
+	{
+		var args = BuildArgs(null);
+
+		Assert.Contains("--remote-debugging-port=0", args);
+		Assert.Contains("--user-data-dir=/tmp/profile", args);
+		Assert.Contains("--headless=new", args);
+		Assert.Equal("about:blank", args[^1]);
+	}
+
+	[Fact]
+	public void ExtraArgumentsAreAppended()
+	{
+		var args = BuildArgs(["--enable-unsafe-webgpu", "--use-webgpu-adapter=swiftshader"]);
+
+		Assert.Contains("--enable-unsafe-webgpu", args);
+		Assert.Contains("--use-webgpu-adapter=swiftshader", args);
+	}
+
+	[Fact]
+	public void ExtraArgumentsComeAfterEverythingTheCliSets()
+	{
+		// Chrome keeps only the last occurrence of most switches, so a caller must be
+		// able to override anything the CLI sets itself.
+		var args = BuildArgs(["--headless=old"]);
+
+		Assert.True(args.IndexOf("--headless=old") > args.IndexOf("--headless=new"));
+	}
+
+	[Fact]
+	public void ExtraArgumentsComeBeforeTheTargetUrl()
+	{
+		// A positional value after the URL would be treated as a second page to open.
+		var args = BuildArgs(["--enable-unsafe-webgpu"]);
+
+		Assert.True(args.IndexOf("--enable-unsafe-webgpu") < args.IndexOf("about:blank"));
+	}
+
+	[Fact]
+	public void ExtraArgumentOrderIsPreserved()
+	{
+		var args = BuildArgs(["--first", "--second", "--third"]);
+
+		Assert.True(args.IndexOf("--first") < args.IndexOf("--second"));
+		Assert.True(args.IndexOf("--second") < args.IndexOf("--third"));
+	}
+
+	[Fact]
+	public void BlankExtraArgumentsAreIgnored()
+	{
+		// Defensive: an empty entry would otherwise become a stray empty token on the
+		// command line.
+		var args = BuildArgs(["", "   ", "--enable-unsafe-webgpu"]);
+
+		Assert.DoesNotContain(args, string.IsNullOrWhiteSpace);
+		Assert.Contains("--enable-unsafe-webgpu", args);
+	}
+
+	[Fact]
+	public void AnArgumentContainingSpacesStaysASingleEntry()
+	{
+		// The shell has already tokenised the command line, so a quoted value arrives as
+		// one entry and must stay that way. Chrome would otherwise treat the trailing
+		// part as an extra page to open and refuse to start ("Multiple targets are not
+		// supported in headless mode").
+		var args = BuildArgs(["--host-resolver-rules=MAP a.test 127.0.0.1"]);
+
+		Assert.Contains("--host-resolver-rules=MAP a.test 127.0.0.1", args);
+	}
+
+	[Fact]
+	public void HeadedModeOmitsTheHeadlessSwitch()
+	{
+		var args = BuildArgs(null, headless: false);
+
+		Assert.DoesNotContain("--headless=new", args);
+	}
+}


### PR DESCRIPTION
## What

The browser that `device-runners wasm test` launches was not configurable in any way, so a
test needing a specific Chrome switch had no route to it.

```bash
device-runners wasm test --app "$wwwroot" --browser-args=--enable-unsafe-webgpu
```

```xml
<PropertyGroup>
  <DeviceRunnersWasmBrowserArgs>--enable-unsafe-webgpu</DeviceRunnersWasmBrowserArgs>
</PropertyGroup>
```

**Passthrough only** — no switch is added by default, so behaviour is unchanged unless a
caller opts in. The full command line is printed as `Browser args:` at the start of every run.

## Scope

Deliberately narrow: this configures the **browser**, not the app under test.

`--` is left unused so it can later mean "arguments for the app under test", which is a
genuinely different thing — on WASM those would become query-string parameters, on Mac
Catalyst process arguments. Reserving it now keeps that door open. Verified that `--` args
are currently accepted and ignored rather than leaking to the browser.

The two channels, for reference:

| Channel | WASM | Android / iOS / macOS / Windows |
| --- | --- | --- |
| Configure the **app under test** | query string `?device-runners-*` | env vars `DEVICE_RUNNERS_*` |
| Configure the **browser** | `--browser-args` ← *this PR* | n/a |

## Quoting

`--browser-args` takes a command-line fragment and splits it with shell quoting rules, so a
switch whose value contains a space just needs quotes:

```xml
<DeviceRunnersWasmBrowserArgs>--enable-unsafe-webgpu "--host-resolver-rules=MAP a.test 127.0.0.1"</DeviceRunnersWasmBrowserArgs>
```

The splitting lives in `ArgumentTokenizer` rather than in MSBuild, where it would have to be
expressed as property functions and couldn't be unit tested. A backslash only escapes inside
double quotes, so Windows paths survive without doubling. Unbalanced quotes are reported
rather than silently swallowing the rest of the line.

The option is repeatable, and the `=` form is required — Spectre.Console treats a following
token starting with `-` as another option, so `--browser-args --enable-unsafe-webgpu` is
rejected. MSBuild emits the `=` form and escapes inner quotes as `\"`, which survives both
cmd.exe and `/bin/sh`.

## Two bugs found while validating end to end

**Arguments containing spaces broke the launch.** They were joined into
`ProcessStartInfo.Arguments` with spaces and never quoted, so Chrome saw the trailing part as
a second page and refused to start with *"Multiple targets are not supported in headless
mode"*. Now uses `ArgumentList`, which quotes each entry.

**Caller switches were added before `--headless=new`,** contradicting the "caller wins"
ordering that Chrome's last-one-wins switch handling implies. Order is now: the CLI's own
switches, then the caller's, then the URL.

## Docs

Rather than baking in defaults, the docs record which switches WebGL and WebGPU actually need
per host OS, measured on GPU-less GitHub-hosted runners with Chrome 150:

| Host | For WebGL | For WebGPU |
| --- | --- | --- |
| Linux | *(works already)* | `--enable-unsafe-webgpu` |
| macOS | `--enable-unsafe-swiftshader` | `--enable-unsafe-webgpu` |
| Windows | *(works already, via D3D11 WARP)* | `--enable-unsafe-webgpu --use-webgpu-adapter=swiftshader` |

Plus the non-obvious parts: on Windows `--enable-unsafe-swiftshader` moves ANGLE onto
SwiftShader and Dawn then can't enumerate any adapter; `--use-webgpu-adapter=swiftshader`
forces software even when a real GPU is present; `--disable-gpu` breaks WebGPU outright; and
`navigator.gpu` only exists in a secure context (`http://127.0.0.1` qualifies, a LAN address
does not).

That's why none of these are defaults — the correct set differs per host, and the only switch
that fixes GPU-less Windows would degrade every developer machine that has a GPU.

## Validation

- 19 unit tests: 11 for the tokenizer (quoting, escapes, Windows paths, empty quoted values,
  unbalanced quotes) and 8 for argument assembly (append order, override semantics, blank
  filtering, space-containing values, headed mode).
- End-to-end on Windows through the full MSBuild → cmd.exe → Spectre → tokenizer → Chrome
  chain, including a `.csproj` property containing an inner quoted value with spaces — it
  reaches Chrome as a single argument (provable because a split would trip "Multiple targets
  are not supported").
- Direct CLI with the `=` form and a quoted space-containing value.
- `--` args confirmed not to reach the browser.
